### PR TITLE
(format) modify header format #10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,9 @@
                         <exclude>**/AbstractBatchDecoder.java</exclude>
                     </excludes>
                     <strictCheck>true</strictCheck>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
             </plugin>
 

--- a/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
+++ b/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/AsyncContext.java
+++ b/src/main/java/com/alipay/remoting/AsyncContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/BaseRemoting.java
+++ b/src/main/java/com/alipay/remoting/BaseRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/BizContext.java
+++ b/src/main/java/com/alipay/remoting/BizContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandCode.java
+++ b/src/main/java/com/alipay/remoting/CommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandDecoder.java
+++ b/src/main/java/com/alipay/remoting/CommandDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandEncoder.java
+++ b/src/main/java/com/alipay/remoting/CommandEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandFactory.java
+++ b/src/main/java/com/alipay/remoting/CommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandHandler.java
+++ b/src/main/java/com/alipay/remoting/CommandHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommonCommandCode.java
+++ b/src/main/java/com/alipay/remoting/CommonCommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Configs.java
+++ b/src/main/java/com/alipay/remoting/Configs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Connection.java
+++ b/src/main/java/com/alipay/remoting/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventListener.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventType.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/ConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionHeartbeatManager.java
+++ b/src/main/java/com/alipay/remoting/ConnectionHeartbeatManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/ConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
+++ b/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionPool.java
+++ b/src/main/java/com/alipay/remoting/ConnectionPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionSelectStrategy.java
+++ b/src/main/java/com/alipay/remoting/ConnectionSelectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CustomSerializer.java
+++ b/src/main/java/com/alipay/remoting/CustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CustomSerializerManager.java
+++ b/src/main/java/com/alipay/remoting/CustomSerializerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultBizContext.java
+++ b/src/main/java/com/alipay/remoting/DefaultBizContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultCustomSerializer.java
+++ b/src/main/java/com/alipay/remoting/DefaultCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/HeartbeatTrigger.java
+++ b/src/main/java/com/alipay/remoting/HeartbeatTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeCallback.java
+++ b/src/main/java/com/alipay/remoting/InvokeCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/InvokeCallbackListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeContext.java
+++ b/src/main/java/com/alipay/remoting/InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeFuture.java
+++ b/src/main/java/com/alipay/remoting/InvokeFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/NamedThreadFactory.java
+++ b/src/main/java/com/alipay/remoting/NamedThreadFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProcessorManager.java
+++ b/src/main/java/com/alipay/remoting/ProcessorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Protocol.java
+++ b/src/main/java/com/alipay/remoting/Protocol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProtocolCode.java
+++ b/src/main/java/com/alipay/remoting/ProtocolCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProtocolManager.java
+++ b/src/main/java/com/alipay/remoting/ProtocolManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RandomSelectStrategy.java
+++ b/src/main/java/com/alipay/remoting/RandomSelectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ReconnectManager.java
+++ b/src/main/java/com/alipay/remoting/ReconnectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingAddressParser.java
+++ b/src/main/java/com/alipay/remoting/RemotingAddressParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingCommand.java
+++ b/src/main/java/com/alipay/remoting/RemotingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingContext.java
+++ b/src/main/java/com/alipay/remoting/RemotingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingProcessor.java
+++ b/src/main/java/com/alipay/remoting/RemotingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingServer.java
+++ b/src/main/java/com/alipay/remoting/RemotingServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ResponseStatus.java
+++ b/src/main/java/com/alipay/remoting/ResponseStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Scannable.java
+++ b/src/main/java/com/alipay/remoting/Scannable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ScheduledDisconnectStrategy.java
+++ b/src/main/java/com/alipay/remoting/ScheduledDisconnectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ServerIdleHandler.java
+++ b/src/main/java/com/alipay/remoting/ServerIdleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/SystemProperties.java
+++ b/src/main/java/com/alipay/remoting/SystemProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/TimerHolder.java
+++ b/src/main/java/com/alipay/remoting/TimerHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Url.java
+++ b/src/main/java/com/alipay/remoting/Url.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedEncoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/CodecException.java
+++ b/src/main/java/com/alipay/remoting/exception/CodecException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/ConnectionClosedException.java
+++ b/src/main/java/com/alipay/remoting/exception/ConnectionClosedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/DeserializationException.java
+++ b/src/main/java/com/alipay/remoting/exception/DeserializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/RemotingException.java
+++ b/src/main/java/com/alipay/remoting/exception/RemotingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/SerializationException.java
+++ b/src/main/java/com/alipay/remoting/exception/SerializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
+++ b/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/DefaultInvokeFuture.java
+++ b/src/main/java/com/alipay/remoting/rpc/DefaultInvokeFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatAckCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatAckCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RequestCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/RequestCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/ResponseCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/ResponseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcAddressParser.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcAddressParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcClientRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClientRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandType.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionEventHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseFuture.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcServerRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServerRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcTaskScanner.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcTaskScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeSendFailedException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeSendFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerBusyException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerBusyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeTimeoutException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeTimeoutException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/RpcServerException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/RpcServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/AsyncUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/AsyncUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandCode.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoderV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoderV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoderV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoderV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcDeserializeLevel.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcDeserializeLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartBeatProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartBeatProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartbeatTrigger.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartbeatTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocol.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolDecoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolManager.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/SyncUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/SyncUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/Serializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/Serializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
+++ b/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ConcurrentHashSet.java
+++ b/src/main/java/com/alipay/remoting/util/ConcurrentHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ConnectionUtil.java
+++ b/src/main/java/com/alipay/remoting/util/ConnectionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/CrcUtil.java
+++ b/src/main/java/com/alipay/remoting/util/CrcUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/FutureTaskNotRunYetException.java
+++ b/src/main/java/com/alipay/remoting/util/FutureTaskNotRunYetException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
+++ b/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/GlobalSwitch.java
+++ b/src/main/java/com/alipay/remoting/util/GlobalSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/IDGenerator.java
+++ b/src/main/java/com/alipay/remoting/util/IDGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ProtocolSwitch.java
+++ b/src/main/java/com/alipay/remoting/util/ProtocolSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/RemotingUtil.java
+++ b/src/main/java/com/alipay/remoting/util/RemotingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/RunStateRecordedFutureTask.java
+++ b/src/main/java/com/alipay/remoting/util/RunStateRecordedFutureTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/StringUtils.java
+++ b/src/main/java/com/alipay/remoting/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/Switch.java
+++ b/src/main/java/com/alipay/remoting/util/Switch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/TraceLogUtil.java
+++ b/src/main/java/com/alipay/remoting/util/TraceLogUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/compatible/BasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/compatible/BasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/BasicUsageDemoByJunit.java
+++ b/src/test/java/com/alipay/remoting/demo/BasicUsageDemoByJunit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/ConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/ConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/UrlTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/UrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/GlobalSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/GlobalSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/ProtocolSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/ProtocolSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/RemotingUtilTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/RemotingUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/SystemPropertiesTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/SystemPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_AsyncProcessor_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_AsyncProcessor_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV1_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV1_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_1_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_1_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_2_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_2_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_SHARE_SAME_SERVER_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_SHARE_SAME_SERVER_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/ServerBasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/ServerBasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/AddressArgs_CONNECTIONNUM_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/AddressArgs_CONNECTIONNUM_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParserTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParser_SOFTREF_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParser_SOFTREF_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/callback/InvokeCallbackTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/callback/InvokeCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/client/ClientConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/client/ClientConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncExceptionUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncExceptionUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/BoltServer.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/BoltServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/CONNECTEventProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/CONNECTEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/ConcurrentServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/ConcurrentServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/DISCONNECTEventProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/DISCONNECTEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/ExceptionUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/ExceptionUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/NullUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/NullUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/PortScan.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/PortScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/RequestBody.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/RequestBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/SimpleClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/SimpleClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/SimpleServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/SimpleServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/connectionmanage/ReconnectManagerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/connectionmanage/ReconnectManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/connectionmanage/ScheduledDisconnectStrategyTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/connectionmanage/ScheduledDisconnectStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BadServerIpTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BadServerIpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Exception_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Exception_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Null_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Null_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerBusyTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerBusyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerInvokeExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerInvokeExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerUnsupportedOperationExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerUnsupportedOperationExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/ClientHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/ClientHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/CustomHeartBeatProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/CustomHeartBeatProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/HeartBeatDisableTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/HeartBeatDisableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/RuntimeClientHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/RuntimeClientHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/ServerHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/ServerHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Url_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Url_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_resuable_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_resuable_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/lock/CreateConnLockTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/lock/CreateConnLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/prehandle/PreHandleUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/prehandle/PreHandleUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/prehandle/PrehandleTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/prehandle/PrehandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/resrelease/ServerClientStopTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/resrelease/ServerClientStopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ClassCustomSerializerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ClassCustomSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/CodecTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/CodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/CustomSerializerCodecTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/CustomSerializerCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionRequestBodyCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionRequestBodyCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionStringCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionStringCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer_InvokeContext.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer_InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer_InvokeContext.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer_InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/TimeoutTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/TimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/BasicUsage_ExecutorSelector_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/BasicUsage_ExecutorSelector_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/CustomHeaderSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/CustomHeaderSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/DefaultExecutorSelector.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/DefaultExecutorSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/BasicUsage_ProcessInIoThread_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/BasicUsage_ProcessInIoThread_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMarkTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMarkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_ExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_init_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_init_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.


### PR DESCRIPTION
uses /* ... */ instead of /** ... */ for license headers in java file, fix #10 