### PR TITLE
Release/1.4.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Ant Financial Services Group Co., Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/alipay/sofa-bolt.svg?branch=master)](https://travis-ci.org/alipay/sofa-bolt)
 [![Coverage Status](https://codecov.io/gh/alipay/sofa-bolt/branch/master/graph/badge.svg)](https://codecov.io/gh/alipay/sofa-bolt)
 ![license](https://img.shields.io/badge/license-Apache--2.0-green.svg)
-![version](https://img.shields.io/badge/bolt-1.4.1-blue.svg)
+![version](https://img.shields.io/badge/bolt-1.4.2-blue.svg)
 
 # 1. 介绍
 SOFABolt 是蚂蚁金融服务集团开发的一套基于 Netty 实现的网络通信框架。

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.alipay.sofa</groupId>
     <artifactId>bolt</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,12 @@
             <version>3.2.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.8.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -380,5 +380,14 @@
                 </snapshotRepository>
             </distributionManagement>
         </profile>
+        <profile>
+            <id>disable-javadoc-doclint</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <configFile>${user.dir}/.middleware-common/AlipayFormatter.xml</configFile>
+                    <configFile>${project.basedir}/.middleware-common/AlipayFormatter.xml</configFile>
                     <encoding>${project.encoding}</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,9 @@
                         <exclude>**/AbstractBatchDecoder.java</exclude>
                     </excludes>
                     <strictCheck>true</strictCheck>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <maven.source.plugin>3.0.0</maven.source.plugin>
         <maven.staging.plugin>1.6.7</maven.staging.plugin>
         <maven.surefire.plugin>2.18.1</maven.surefire.plugin>
-        <netty.version>4.1.13.Final</netty.version>
+        <netty.version>4.1.25.Final</netty.version>
         <project.encoding>UTF-8</project.encoding>
         <slf4j.version>1.7.21</slf4j.version>
         <sofa.common.tools>1.0.12</sofa.common.tools>

--- a/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
+++ b/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/AsyncContext.java
+++ b/src/main/java/com/alipay/remoting/AsyncContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/BaseRemoting.java
+++ b/src/main/java/com/alipay/remoting/BaseRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/BizContext.java
+++ b/src/main/java/com/alipay/remoting/BizContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandCode.java
+++ b/src/main/java/com/alipay/remoting/CommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandDecoder.java
+++ b/src/main/java/com/alipay/remoting/CommandDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandEncoder.java
+++ b/src/main/java/com/alipay/remoting/CommandEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandFactory.java
+++ b/src/main/java/com/alipay/remoting/CommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommandHandler.java
+++ b/src/main/java/com/alipay/remoting/CommandHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CommonCommandCode.java
+++ b/src/main/java/com/alipay/remoting/CommonCommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Configs.java
+++ b/src/main/java/com/alipay/remoting/Configs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Connection.java
+++ b/src/main/java/com/alipay/remoting/Connection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventHandler.java
@@ -263,7 +263,7 @@ public class ConnectionEventHandler extends ChannelDuplexHandler {
         Logger          logger   = BoltLoggerFactory.getLogger("CommonDefault");
         ExecutorService executor = new ThreadPoolExecutor(1, 1, 60L, TimeUnit.SECONDS,
                                      new LinkedBlockingQueue<Runnable>(10000),
-                                     new NamedThreadFactory("Bolt-conn-event-executor"));
+                                     new NamedThreadFactory("Bolt-conn-event-executor", true));
 
         /**
          * Process event.

--- a/src/main/java/com/alipay/remoting/ConnectionEventListener.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionEventType.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/ConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionHeartbeatManager.java
+++ b/src/main/java/com/alipay/remoting/ConnectionHeartbeatManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/ConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
+++ b/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionPool.java
+++ b/src/main/java/com/alipay/remoting/ConnectionPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ConnectionSelectStrategy.java
+++ b/src/main/java/com/alipay/remoting/ConnectionSelectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CustomSerializer.java
+++ b/src/main/java/com/alipay/remoting/CustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/CustomSerializerManager.java
+++ b/src/main/java/com/alipay/remoting/CustomSerializerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultBizContext.java
+++ b/src/main/java/com/alipay/remoting/DefaultBizContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionManager.java
@@ -843,7 +843,7 @@ public class DefaultConnectionManager implements ConnectionManager, ConnectionHe
             this.executorInitialized = true;
             this.asyncCreateConnectionExecutor = new ThreadPoolExecutor(minPoolSize, maxPoolSize,
                 keepAliveTime, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(queueSize),
-                new NamedThreadFactory("Bolt-conn-warmup-executor"));
+                new NamedThreadFactory("Bolt-conn-warmup-executor", true));
         }
     }
 

--- a/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
+++ b/src/main/java/com/alipay/remoting/DefaultConnectionMonitor.java
@@ -62,7 +62,7 @@ public class DefaultConnectionMonitor {
         long period = SystemProperties.conn_monitor_period();
 
         this.executor = new ScheduledThreadPoolExecutor(1, new NamedThreadFactory(
-            "ConnectionMonitorThread"), new ThreadPoolExecutor.AbortPolicy());
+            "ConnectionMonitorThread", true), new ThreadPoolExecutor.AbortPolicy());
         MonitorTask monitorTask = new MonitorTask();
         this.executor.scheduleAtFixedRate(monitorTask, initialDelay, period, TimeUnit.MILLISECONDS);
     }

--- a/src/main/java/com/alipay/remoting/DefaultCustomSerializer.java
+++ b/src/main/java/com/alipay/remoting/DefaultCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/HeartbeatTrigger.java
+++ b/src/main/java/com/alipay/remoting/HeartbeatTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeCallback.java
+++ b/src/main/java/com/alipay/remoting/InvokeCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/InvokeCallbackListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeContext.java
+++ b/src/main/java/com/alipay/remoting/InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/InvokeFuture.java
+++ b/src/main/java/com/alipay/remoting/InvokeFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/NamedThreadFactory.java
+++ b/src/main/java/com/alipay/remoting/NamedThreadFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProcessorManager.java
+++ b/src/main/java/com/alipay/remoting/ProcessorManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProcessorManager.java
+++ b/src/main/java/com/alipay/remoting/ProcessorManager.java
@@ -59,7 +59,7 @@ public class ProcessorManager {
     public ProcessorManager() {
         defaultExecutor = new ThreadPoolExecutor(minPoolSize, maxPoolSize, keepAliveTime,
             TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(queueSize), new NamedThreadFactory(
-                "Bolt-default-executor"));
+                "Bolt-default-executor", true));
     }
 
     /**

--- a/src/main/java/com/alipay/remoting/Protocol.java
+++ b/src/main/java/com/alipay/remoting/Protocol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProtocolCode.java
+++ b/src/main/java/com/alipay/remoting/ProtocolCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ProtocolManager.java
+++ b/src/main/java/com/alipay/remoting/ProtocolManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RandomSelectStrategy.java
+++ b/src/main/java/com/alipay/remoting/RandomSelectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ReconnectManager.java
+++ b/src/main/java/com/alipay/remoting/ReconnectManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingAddressParser.java
+++ b/src/main/java/com/alipay/remoting/RemotingAddressParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingCommand.java
+++ b/src/main/java/com/alipay/remoting/RemotingCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingContext.java
+++ b/src/main/java/com/alipay/remoting/RemotingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingProcessor.java
+++ b/src/main/java/com/alipay/remoting/RemotingProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingServer.java
+++ b/src/main/java/com/alipay/remoting/RemotingServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/RemotingServer.java
+++ b/src/main/java/com/alipay/remoting/RemotingServer.java
@@ -71,6 +71,7 @@ public abstract class RemotingServer {
                 return this.doStart();
             } catch (Throwable t) {
                 started.set(false);
+                this.stop();
                 logger.error("ERROR: Failed to start the Server!", t);
                 return false;
             }
@@ -92,6 +93,7 @@ public abstract class RemotingServer {
                 return this.doStart(ip);
             } catch (Throwable t) {
                 started.set(false);
+                this.stop();
                 logger.error("ERROR: Failed to start the Server!", t);
                 return false;
             }
@@ -110,7 +112,9 @@ public abstract class RemotingServer {
      *   <li>If you need, you should destroy it, and instantiate another one.
      */
     public void stop() {
-        if (started.compareAndSet(true, false)) {
+        if (inited.get() || started.get()) {
+            inited.compareAndSet(true, false);
+            started.compareAndSet(true, false);
             this.doStop();
         } else {
             throw new IllegalStateException("ERROR: The server has already stopped!");

--- a/src/main/java/com/alipay/remoting/RemotingServer.java
+++ b/src/main/java/com/alipay/remoting/RemotingServer.java
@@ -75,8 +75,9 @@ public abstract class RemotingServer {
                 return false;
             }
         } else {
-            logger.error("ERROR: The server has already started!");
-            return false;
+            String errMsg = "ERROR: The server has already started!";
+            logger.error(errMsg);
+            throw new IllegalStateException(errMsg);
         }
     }
 
@@ -95,8 +96,9 @@ public abstract class RemotingServer {
                 return false;
             }
         } else {
-            logger.error("ERROR: The server has already started!");
-            return false;
+            String errMsg = "ERROR: The server has already started!";
+            logger.error(errMsg);
+            throw new IllegalStateException(errMsg);
         }
     }
 

--- a/src/main/java/com/alipay/remoting/ResponseStatus.java
+++ b/src/main/java/com/alipay/remoting/ResponseStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/Scannable.java
+++ b/src/main/java/com/alipay/remoting/Scannable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ScheduledDisconnectStrategy.java
+++ b/src/main/java/com/alipay/remoting/ScheduledDisconnectStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/ServerIdleHandler.java
+++ b/src/main/java/com/alipay/remoting/ServerIdleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/SystemProperties.java
+++ b/src/main/java/com/alipay/remoting/SystemProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/TimerHolder.java
+++ b/src/main/java/com/alipay/remoting/TimerHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/TimerHolder.java
+++ b/src/main/java/com/alipay/remoting/TimerHolder.java
@@ -33,8 +33,8 @@ public class TimerHolder {
 
     private static class DefaultInstance {
         static final Timer INSTANCE = new HashedWheelTimer(new NamedThreadFactory(
-                                        "DefaultTimer" + defaultTickDuration), defaultTickDuration,
-                                        TimeUnit.MILLISECONDS);
+                                        "DefaultTimer" + defaultTickDuration, true),
+                                        defaultTickDuration, TimeUnit.MILLISECONDS);
     }
 
     private TimerHolder() {

--- a/src/main/java/com/alipay/remoting/Url.java
+++ b/src/main/java/com/alipay/remoting/Url.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedEncoder.java
+++ b/src/main/java/com/alipay/remoting/codec/ProtocolCodeBasedEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/CodecException.java
+++ b/src/main/java/com/alipay/remoting/exception/CodecException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/ConnectionClosedException.java
+++ b/src/main/java/com/alipay/remoting/exception/ConnectionClosedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/DeserializationException.java
+++ b/src/main/java/com/alipay/remoting/exception/DeserializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/RemotingException.java
+++ b/src/main/java/com/alipay/remoting/exception/RemotingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/exception/SerializationException.java
+++ b/src/main/java/com/alipay/remoting/exception/SerializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
+++ b/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
+++ b/src/main/java/com/alipay/remoting/log/BoltLoggerFactory.java
@@ -42,6 +42,7 @@ public class BoltLoggerFactory {
     private static final String CLIENT_LOG_LEVEL          = "com.alipay.remoting.client.log.level";
     private static final String CLIENT_LOG_LEVEL_DEFAULT  = "INFO";
     private static final String CLIENT_LOG_ENCODE         = "com.alipay.remoting.client.log.encode";
+    private static final String COMMON_ENCODE             = "file.encoding";
     private static final String CLIENT_LOG_ENCODE_DEFAULT = "UTF-8";
 
     static {
@@ -51,16 +52,23 @@ public class BoltLoggerFactory {
         }
 
         String logPath = System.getProperty(LOG_PATH);
-        String logLevel = System.getProperty(CLIENT_LOG_LEVEL);
-        String logEncode = System.getProperty(CLIENT_LOG_ENCODE);
         if (StringUtils.isBlank(logPath)) {
             System.setProperty(LOG_PATH, LOG_PATH_DEFAULT);
         }
+
+        String logLevel = System.getProperty(CLIENT_LOG_LEVEL);
         if (StringUtils.isBlank(logLevel)) {
             System.setProperty(CLIENT_LOG_LEVEL, CLIENT_LOG_LEVEL_DEFAULT);
         }
-        if (StringUtils.isBlank(logEncode)) {
-            System.setProperty(CLIENT_LOG_ENCODE, CLIENT_LOG_ENCODE_DEFAULT);
+
+        String commonEncode = System.getProperty(COMMON_ENCODE);
+        if (StringUtils.isNotBlank(commonEncode)) {
+            System.setProperty(CLIENT_LOG_ENCODE, commonEncode);
+        } else {
+            String logEncode = System.getProperty(CLIENT_LOG_ENCODE);
+            if (StringUtils.isBlank(logEncode)) {
+                System.setProperty(CLIENT_LOG_ENCODE, CLIENT_LOG_ENCODE_DEFAULT);
+            }
         }
     }
 

--- a/src/main/java/com/alipay/remoting/rpc/DefaultInvokeFuture.java
+++ b/src/main/java/com/alipay/remoting/rpc/DefaultInvokeFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatAckCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatAckCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/HeartbeatHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/HeartbeatHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RequestCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/RequestCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/ResponseCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/ResponseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcAddressParser.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcAddressParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcClientRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClientRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandType.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionEventHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionEventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
@@ -70,7 +70,8 @@ public class RpcConnectionFactory implements ConnectionFactory {
                                                                                .getRuntime()
                                                                                .availableProcessors() + 1,
                                                                            new NamedThreadFactory(
-                                                                               "Rpc-netty-client-worker"));
+                                                                               "Rpc-netty-client-worker",
+                                                                               true));
 
     private Bootstrap                                   bootstrap;
 

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+import io.netty.buffer.UnpooledByteBufAllocator;
 import org.slf4j.Logger;
 
 import com.alipay.remoting.Connection;
@@ -87,14 +88,14 @@ public class RpcConnectionFactory implements ConnectionFactory {
             .option(ChannelOption.SO_REUSEADDR, SystemProperties.tcp_so_reuseaddr())
             .option(ChannelOption.SO_KEEPALIVE, SystemProperties.tcp_so_keepalive());
 
-        /**
-         * init netty write buffer water mark
-         */
+        // init netty write buffer water mark
         initWriteBufferWaterMark();
 
-        boolean pooledBuffer = SystemProperties.netty_buffer_pooled();
-        if (pooledBuffer) {
-            bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+        // init byte buf allocator
+        if (SystemProperties.netty_buffer_pooled()) {
+            this.bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+        } else {
+            this.bootstrap.option(ChannelOption.ALLOCATOR, UnpooledByteBufAllocator.DEFAULT);
         }
 
         final boolean idleSwitch = SystemProperties.tcp_idle_switch();

--- a/src/main/java/com/alipay/remoting/rpc/RpcHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcInvokeCallbackListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseFuture.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseFuture.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -102,14 +102,16 @@ public class RpcServer extends RemotingServer {
     private final EventLoopGroup                        bossGroup               = new NioEventLoopGroup(
                                                                                     1,
                                                                                     new NamedThreadFactory(
-                                                                                        "Rpc-netty-server-boss"));
+                                                                                        "Rpc-netty-server-boss",
+                                                                                        true));
     /** worker event loop group. Reuse I/O worker threads between rpc servers. */
     private final static NioEventLoopGroup              workerGroup             = new NioEventLoopGroup(
                                                                                     Runtime
                                                                                         .getRuntime()
                                                                                         .availableProcessors() * 2,
                                                                                     new NamedThreadFactory(
-                                                                                        "Rpc-netty-server-worker"));
+                                                                                        "Rpc-netty-server-worker",
+                                                                                        true));
 
     /** address parser to get custom args */
     private RemotingAddressParser                       addressParser;

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -103,7 +103,7 @@ public class RpcServer extends RemotingServer {
                                                                                     1,
                                                                                     new NamedThreadFactory(
                                                                                         "Rpc-netty-server-boss",
-                                                                                        true));
+                                                                                        false));
     /** worker event loop group. Reuse I/O worker threads between rpc servers. */
     private final static NioEventLoopGroup              workerGroup             = new NioEventLoopGroup(
                                                                                     Runtime

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -71,6 +71,13 @@ import io.netty.handler.timeout.IdleStateHandler;
 /**
  * Server for Rpc.
  *
+ * Usage:
+ * You can initialize RpcServer with one of the three constructors:
+ *   {@link #RpcServer(int)}, {@link #RpcServer(int, boolean)}, {@link #RpcServer(int, boolean, boolean)}
+ * Then call start() to start a rpc server, and call stop() to stop a rpc server.
+ * When rpc server has been stopped, it can not be start again.
+ * You should create another instance of RpcServer to start if you need.
+ *
  * @author jiangping
  * @version $Id: RpcServer.java, v 0.1 2015-8-31 PM5:22:22 tao Exp $
  */
@@ -98,7 +105,7 @@ public class RpcServer extends RemotingServer {
     private ConcurrentHashMap<String, UserProcessor<?>> userProcessors          = new ConcurrentHashMap<String, UserProcessor<?>>(
                                                                                     4);
 
-    /** boss event loop group*/
+    /** boss event loop group, boss group should not be daemon, need shutdown manually */
     private final EventLoopGroup                        bossGroup               = new NioEventLoopGroup(
                                                                                     1,
                                                                                     new NamedThreadFactory(
@@ -282,7 +289,9 @@ public class RpcServer extends RemotingServer {
      */
     @Override
     protected void doStop() {
-        this.channelFuture.channel().close();
+        if (null != this.channelFuture) {
+            this.channelFuture.channel().close();
+        }
         if (this.globalSwitch.isOn(GlobalSwitch.SERVER_SYNC_STOP)) {
             this.bossGroup.shutdownGracefully().awaitUninterruptibly();
         } else {

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -49,12 +49,13 @@ import com.alipay.remoting.rpc.protocol.RpcProtocolDecoder;
 import com.alipay.remoting.rpc.protocol.RpcProtocolManager;
 import com.alipay.remoting.rpc.protocol.RpcProtocolV2;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
+import com.alipay.remoting.util.GlobalSwitch;
 import com.alipay.remoting.util.RemotingUtil;
 import com.alipay.remoting.util.StringUtils;
-import com.alipay.remoting.util.GlobalSwitch;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -78,7 +79,6 @@ public class RpcServer extends RemotingServer {
     /** logger */
     private static final Logger                         logger                  = BoltLoggerFactory
                                                                                     .getLogger("RpcRemoting");
-
     /** server bootstrap */
     private ServerBootstrap                             bootstrap;
 
@@ -200,10 +200,13 @@ public class RpcServer extends RemotingServer {
         // set write buffer water mark
         initWriteBufferWaterMark();
 
-        boolean pooledBuffer = SystemProperties.netty_buffer_pooled();
-        if (pooledBuffer) {
+        // init byte buf allocator
+        if (SystemProperties.netty_buffer_pooled()) {
             this.bootstrap.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+        } else {
+            this.bootstrap.option(ChannelOption.ALLOCATOR, UnpooledByteBufAllocator.DEFAULT)
+                .childOption(ChannelOption.ALLOCATOR, UnpooledByteBufAllocator.DEFAULT);
         }
 
         final boolean idleSwitch = SystemProperties.tcp_idle_switch();

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -75,8 +75,9 @@ import io.netty.handler.timeout.IdleStateHandler;
  * You can initialize RpcServer with one of the three constructors:
  *   {@link #RpcServer(int)}, {@link #RpcServer(int, boolean)}, {@link #RpcServer(int, boolean, boolean)}
  * Then call start() to start a rpc server, and call stop() to stop a rpc server.
- * When rpc server has been stopped, it can not be start again.
- * You should create another instance of RpcServer to start if you need.
+ *
+ * Notice:
+ *   Once rpc server has been stopped, it can never be start again. You should init another instance of RpcServer to use.
  *
  * @author jiangping
  * @version $Id: RpcServer.java, v 0.1 2015-8-31 PM5:22:22 tao Exp $

--- a/src/main/java/com/alipay/remoting/rpc/RpcServerRemoting.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServerRemoting.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/RpcTaskScanner.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcTaskScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeSendFailedException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeSendFailedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerBusyException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerBusyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/InvokeTimeoutException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/InvokeTimeoutException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/exception/RpcServerException.java
+++ b/src/main/java/com/alipay/remoting/rpc/exception/RpcServerException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/AbstractUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/AsyncUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/AsyncUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcAsyncContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandCode.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoderV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandDecoderV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoderV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandEncoderV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcDeserializeLevel.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcDeserializeLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartBeatProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartBeatProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartbeatTrigger.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcHeartbeatTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocol.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolDecoder.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolDecoder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolManager.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolV2.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcProtocolV2.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseCommand.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcResponseProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/SyncUserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/SyncUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/UserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/HessianSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/Serializer.java
+++ b/src/main/java/com/alipay/remoting/serialization/Serializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
+++ b/src/main/java/com/alipay/remoting/serialization/SerializerManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ConcurrentHashSet.java
+++ b/src/main/java/com/alipay/remoting/util/ConcurrentHashSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ConnectionUtil.java
+++ b/src/main/java/com/alipay/remoting/util/ConnectionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/CrcUtil.java
+++ b/src/main/java/com/alipay/remoting/util/CrcUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/FutureTaskNotRunYetException.java
+++ b/src/main/java/com/alipay/remoting/util/FutureTaskNotRunYetException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
+++ b/src/main/java/com/alipay/remoting/util/FutureTaskUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/GlobalSwitch.java
+++ b/src/main/java/com/alipay/remoting/util/GlobalSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/IDGenerator.java
+++ b/src/main/java/com/alipay/remoting/util/IDGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/ProtocolSwitch.java
+++ b/src/main/java/com/alipay/remoting/util/ProtocolSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/RemotingUtil.java
+++ b/src/main/java/com/alipay/remoting/util/RemotingUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/RunStateRecordedFutureTask.java
+++ b/src/main/java/com/alipay/remoting/util/RunStateRecordedFutureTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/StringUtils.java
+++ b/src/main/java/com/alipay/remoting/util/StringUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/Switch.java
+++ b/src/main/java/com/alipay/remoting/util/Switch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/java/com/alipay/remoting/util/TraceLogUtil.java
+++ b/src/main/java/com/alipay/remoting/util/TraceLogUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/main/resources/com/alipay/remoting/log/log4j/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/log4j/log-conf.xml
@@ -148,4 +148,10 @@
         <appender-ref ref="HttpRemotingAppender"/>
         <appender-ref ref="ERROR-APPENDER"/>
     </logger>
+
+    <root>
+        <level value="${com.alipay.remoting.client.log.level}"/>
+        <appender-ref ref="CommonDefaultAppender"/>
+        <appender-ref ref="ERROR-APPENDER"/>
+    </root>
 </log4j:configuration>

--- a/src/main/resources/com/alipay/remoting/log/log4j2/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/log4j2/log-conf.xml
@@ -167,5 +167,10 @@
             <appender-ref ref="HttpRemotingAppender"/>
             <appender-ref ref="ERROR-APPENDER"/>
         </AsyncLogger>
+
+        <root level="${LOG_LEVEL}">
+            <appender-ref ref="CommonDefaultAppender"/>
+            <appender-ref ref="ERROR-APPENDER"/>
+        </root>
     </Loggers>
 </Configuration>

--- a/src/main/resources/com/alipay/remoting/log/logback/log-conf.xml
+++ b/src/main/resources/com/alipay/remoting/log/logback/log-conf.xml
@@ -200,4 +200,9 @@
         <appender-ref ref="HttpRemotingAppender"/>
         <appender-ref ref="ERROR-APPENDER"/>
     </logger>
+
+    <root level="${LOG_LEVEL}">
+        <appender-ref ref="CommonDefaultAppender"/>
+        <appender-ref ref="ERROR-APPENDER"/>
+    </root>
 </configuration>

--- a/src/test/java/com/alipay/remoting/RemotingServerTest.java
+++ b/src/test/java/com/alipay/remoting/RemotingServerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/RemotingServerTest.java
+++ b/src/test/java/com/alipay/remoting/RemotingServerTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting;
+
+import com.alipay.remoting.rpc.RpcServer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * test {@link RemotingServer} apis
+ *
+ * @author tsui
+ * @version $Id: RemotingServerTest.java, v 0.1 May 16, 2018 10:00:48 AM tsui Exp $
+ */
+public class RemotingServerTest {
+    @Test
+    public void testStartRepeatedly() {
+        RpcServer rpcServer = new RpcServer(1111);
+        rpcServer.start();
+
+        try {
+            Assert.assertTrue(rpcServer.start());
+            Assert.fail("Should not reach here!");
+        } catch (Exception e) {
+            // expect IllegalStateException
+        }
+        rpcServer.stop();
+    }
+
+    @Test
+    public void testStartFailed() throws InterruptedException {
+        RemotingServer remotingServer = Mockito.mock(RemotingServer.class);
+        when(remotingServer.doStart()).thenThrow(new RuntimeException("start error"));
+        try {
+            Assert.assertFalse(remotingServer.start());
+        } catch (Exception e) {
+            Assert.fail("Should not reach here!");
+        }
+    }
+
+    @Test
+    public void testStopRepeatedly() {
+        RpcServer rpcServer = new RpcServer(1111);
+        try {
+            Assert.assertTrue(rpcServer.start());
+        } catch (Exception e) {
+            Assert.fail("Should not reach here!");
+            e.printStackTrace();
+        }
+        rpcServer.stop();
+        try {
+            rpcServer.stop();
+            Assert.fail("Should not reach here!");
+        } catch (Exception e) {
+            // expect IllegalStateException
+        }
+    }
+}

--- a/src/test/java/com/alipay/remoting/compatible/BasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/compatible/BasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/BasicUsageDemoByJunit.java
+++ b/src/test/java/com/alipay/remoting/demo/BasicUsageDemoByJunit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcClientDemoByMain.java
@@ -67,7 +67,7 @@ public class RpcClientDemoByMain {
             logger.error(errMsg, e);
             Assert.fail(errMsg);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            logger.error("interrupted!");
         }
         client.shutdown();
     }

--- a/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
+++ b/src/test/java/com/alipay/remoting/demo/RpcServerDemoByMain.java
@@ -52,8 +52,12 @@ public class RpcServerDemoByMain {
         // 3. register user processor for client request
         server.registerUserProcessor(serverUserProcessor);
         // 4. server start
-        server.start();
-        System.out.println("server start ok!");
+        if (server.start()) {
+            System.out.println("server start ok!");
+        } else {
+            System.out.println("server start failed!");
+        }
+        // server.getRpcServer().stop();
     }
 
     public static void main(String[] args) {

--- a/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/ConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/ConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/connection/UrlTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/UrlTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/GlobalSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/GlobalSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/ProtocolSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/ProtocolSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/RemotingUtilTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/RemotingUtilTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/StringUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/inner/utiltest/SystemPropertiesTest.java
+++ b/src/test/java/com/alipay/remoting/inner/utiltest/SystemPropertiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_AsyncProcessor_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_AsyncProcessor_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV1_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV1_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_1_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_1_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_2_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_ProtocolV2_2_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/BasicUsage_SHARE_SAME_SERVER_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/BasicUsage_SHARE_SAME_SERVER_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/RpcServerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/RpcServerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** 
+ * test rpc server and stop logic
+ *
+ * @author tsui  
+ * @version $Id: RpcServerTest.java, v 0.1 2018-05-29 15:27 tsui Exp $$  
+ */
+public class RpcServerTest {
+    static Logger logger = LoggerFactory.getLogger(RpcServerTest.class);
+
+    @Before
+    public void init() {
+    }
+
+    @After
+    public void stop() {
+    }
+
+    @Test
+    public void doTestStartAndStop() {
+        doTestStartAndStop(true);
+        doTestStartAndStop(false);
+    }
+
+    private void doTestStartAndStop(boolean syncStop) {
+        // 1. start a rpc server successfully
+        RpcServer rpcServer1 = new RpcServer(1111, false, syncStop);
+        if (!rpcServer1.start()) {
+            Assert.fail("Should not reach here");
+            logger.warn("start fail");
+        } else {
+            logger.warn("start success");
+        }
+
+        // 2. start a rpc server with the same port number failed
+        RpcServer rpcServer2 = new RpcServer(1111, false, syncStop);
+        if (!rpcServer2.start()) {
+            logger.warn("start fail");
+        } else {
+            Assert.fail("Should not reach here");
+            logger.warn("start success");
+        }
+
+        // 3. stop the first rpc server successfully
+        try {
+            rpcServer1.stop();
+        } catch (IllegalStateException e) {
+            Assert.fail("Should not reach here");
+        }
+
+        // 4. stop the second rpc server failed, for if start failed, stop method will be called automatically
+        try {
+            rpcServer2.stop();
+            Assert.fail("Should not reach here");
+        } catch (IllegalStateException e) {
+            // expect
+        }
+    }
+}

--- a/src/test/java/com/alipay/remoting/rpc/ServerBasicUsageTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/ServerBasicUsageTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/AddressArgs_CONNECTIONNUM_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/AddressArgs_CONNECTIONNUM_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParserTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParser_SOFTREF_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/addressargs/RpcAddressParser_SOFTREF_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/callback/InvokeCallbackTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/callback/InvokeCallbackTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/client/ClientConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/client/ClientConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncExceptionUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncExceptionUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/AsyncServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/BoltServer.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/BoltServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/CONNECTEventProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/CONNECTEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/ConcurrentServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/ConcurrentServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/DISCONNECTEventProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/DISCONNECTEventProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/ExceptionUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/ExceptionUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/NullUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/NullUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/PortScan.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/PortScan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/RequestBody.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/RequestBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/SimpleClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/SimpleClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/common/SimpleServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/common/SimpleServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/connectionmanage/ReconnectManagerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/connectionmanage/ReconnectManagerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/connectionmanage/ScheduledDisconnectStrategyTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/connectionmanage/ScheduledDisconnectStrategyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BadServerIpTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BadServerIpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Exception_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Exception_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Null_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/BasicUsage_AsyncProcessor_Null_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerBusyTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerBusyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerInvokeExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerInvokeExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/exception/ServerUnsupportedOperationExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/exception/ServerUnsupportedOperationExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/ClientHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/ClientHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/CustomHeartBeatProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/CustomHeartBeatProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/HeartBeatDisableTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/HeartBeatDisableTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/RuntimeClientHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/RuntimeClientHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/heartbeat/ServerHeartBeatTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/heartbeat/ServerHeartBeatTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Url_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_Url_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_resuable_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/invokecontext/BasicUsage_InvokeContext_resuable_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/lock/CreateConnLockTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/lock/CreateConnLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/prehandle/PreHandleUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/prehandle/PreHandleUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/prehandle/PrehandleTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/prehandle/PrehandleTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/resrelease/ServerClientStopTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/resrelease/ServerClientStopTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ClassCustomSerializerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ClassCustomSerializerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/CodecTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/CodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/CustomSerializerCodecTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/CustomSerializerCodecTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionRequestBodyCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionRequestBodyCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionStringCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/ExceptionStringCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer_InvokeContext.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalRequestBodyCustomSerializer_InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer_InvokeContext.java
+++ b/src/test/java/com/alipay/remoting/rpc/serializer/NormalStringCustomSerializer_InvokeContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutSwitchTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutSwitchTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/ServerTimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/timeout/TimeoutTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/timeout/TimeoutTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/BasicUsage_ExecutorSelector_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/BasicUsage_ExecutorSelector_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/CustomHeaderSerializer.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/CustomHeaderSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/DefaultExecutorSelector.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/DefaultExecutorSelector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/executorselector/SpecificServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/BasicUsage_ProcessInIoThread_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/BasicUsage_ProcessInIoThread_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificClientUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificClientUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificServerUserProcessor.java
+++ b/src/test/java/com/alipay/remoting/rpc/userprocessor/processinio/SpecificServerUserProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMarkTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMarkTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_ExceptionTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_ExceptionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_init_Test.java
+++ b/src/test/java/com/alipay/remoting/rpc/watermark/WaterMark_init_Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/src/test/java/com/alipay/remoting/util/ThreadTestUtils.java
+++ b/src/test/java/com/alipay/remoting/util/ThreadTestUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.util;
+
+/** 
+ * utils of thread operations
+ *
+ * @author tsui  
+ * @version $Id: ThreadTestUtils.java, v 0.1 2018-05-29 15:29 tsui Exp $$  
+ */
+public class ThreadTestUtils {
+    public static void sleep(long duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            //ignore
+        }
+    }
+}


### PR DESCRIPTION
## 所有MR见[milestone1.4.2](https://github.com/alipay/sofa-bolt/pulls?q=is%3Apr+is%3Aclosed+milestone%3A%22v1.4.2+release%22)，修改内容包括：
1. 修复主线程结束后，bolt内部线程池没有自动关闭的问题。目前除了RpcServer的boss线程非daemon，其他都已改成daemon。具体见PR[!31](https://github.com/alipay/sofa-bolt/pull/31/files)以及commit 06398729e98d1ac5779566dfd64be127c2745914
2. rpc server的初始化逻辑修改，抽象一个initRpcRemoting接口，子类可以覆写。
3. 调整RemotingServer的启动逻辑，当重复启动时，抛IllegalStateException异常，与重复stop抛的异常一致。另外启动失败后，主动调用一个stop方法，为了状态一致并且释放已经init的资源。
3. ByteBufAllocator初始化逻辑修改，以bolt的开关为准，bolt目前默认是UnpooledByteBufAllocator
4. 日志修改：增加rootLogger，增加支持encoding系统参数：`"file.encoding"`
5. 格式修改：license头uses `/* ... */ `instead of` /** ... */ `；
6. mvn插件修改：增加disable-javadoc-doclint，解决1.8下面的编译异常。
8. netty版本从4.1.13.Final升级到4.1.25.Final