### PR TITLE
(tuning) fix #44

### DIFF
--- a/src/main/java/com/alipay/remoting/RemotingServer.java
+++ b/src/main/java/com/alipay/remoting/RemotingServer.java
@@ -26,6 +26,11 @@ import com.alipay.remoting.rpc.protocol.UserProcessor;
 public interface RemotingServer {
 
     /**
+     * init the server
+     */
+    void init();
+
+    /**
      * Start the server.
      */
     boolean start();

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -323,7 +323,8 @@ public class RpcServer extends AbstractRemotingServer implements RemotingServer 
         } else {
             this.bossGroup.shutdownGracefully();
         }
-        if (this.globalSwitch.isOn(GlobalSwitch.SERVER_MANAGE_CONNECTION_SWITCH)) {
+        if (this.globalSwitch.isOn(GlobalSwitch.SERVER_MANAGE_CONNECTION_SWITCH)
+            && null != this.connectionManager) {
             this.connectionManager.removeAll();
             logger.warn("Close all connections from server side!");
         }


### PR DESCRIPTION
1. detail exception print when server start failed.
2. add an init phase, in order to ensure resources closed during init operation when start failed.