### PR TITLE
(tuning) fix #22

### DIFF
--- a/src/main/java/com/alipay/remoting/CommandFactory.java
+++ b/src/main/java/com/alipay/remoting/CommandFactory.java
@@ -54,6 +54,9 @@ public interface CommandFactory {
 
     <T extends RemotingCommand> T createExceptionResponse(int id, ResponseStatus status);
 
+    <T extends RemotingCommand> T createExceptionResponse(int id, ResponseStatus status,
+                                                          final Throwable t);
+
     <T extends RemotingCommand> T createTimeoutResponse(final InetSocketAddress address);
 
     <T extends RemotingCommand> T createSendFailedResponse(final InetSocketAddress address,

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -125,9 +125,10 @@ public class RpcCommandFactory implements CommandFactory {
     }
 
     /**
-     * create server exception using error msg and throwable
-     * @param t
-     * @param errMsg
+     * create server exception using error msg and throwable.
+     *
+     * @param t the origin throwable to fill the stack trace of rpc server exception
+     * @param errMsg additional error msg, <code>null</code> is allowed
      * @return
      */
     private RpcServerException createServerException(Throwable t, String errMsg) {

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -60,17 +60,12 @@ public class RpcCommandFactory implements CommandFactory {
     @Override
     public RpcResponseCommand createExceptionResponse(int id, final Throwable t, String errMsg) {
         RpcResponseCommand response = null;
-        RpcServerException e = null;
         if (null == t) {
-            e = new RpcServerException(errMsg);
-            response = new RpcResponseCommand(id, e);
+            response = new RpcResponseCommand(id, createServerException(errMsg));
         } else {
-            e = new RpcServerException(t.getClass().getName() + ": " + t.getMessage()
-                                       + ". AdditionalErrMsg: " + errMsg);
-            e.setStackTrace(t.getStackTrace());
-            response = new RpcResponseCommand(id, e);
+            response = new RpcResponseCommand(id, createServerException(t, errMsg));
         }
-        response.setResponseClass(e.getClass().getName());
+        response.setResponseClass(RpcServerException.class.getName());
         response.setResponseStatus(ResponseStatus.SERVER_EXCEPTION);
         return response;
     }
@@ -80,6 +75,14 @@ public class RpcCommandFactory implements CommandFactory {
         RpcResponseCommand responseCommand = new RpcResponseCommand();
         responseCommand.setId(id);
         responseCommand.setResponseStatus(status);
+        return responseCommand;
+    }
+
+    @Override
+    public RpcResponseCommand createExceptionResponse(int id, ResponseStatus status, Throwable t) {
+        RpcResponseCommand responseCommand = this.createExceptionResponse(id, status);
+        responseCommand.setResponseObject(createServerException(t, null));
+        responseCommand.setResponseClass(RpcServerException.class.getName());
         return responseCommand;
     }
 
@@ -110,5 +113,28 @@ public class RpcCommandFactory implements CommandFactory {
         responseCommand.setResponseTimeMillis(System.currentTimeMillis());
         responseCommand.setResponseHost(address);
         return responseCommand;
+    }
+
+    /**
+     * create server exception using error msg
+     * @param errMsg
+     * @return
+     */
+    private RpcServerException createServerException(String errMsg) {
+        return new RpcServerException(errMsg);
+    }
+
+    /**
+     * create server exception using error msg and throwable
+     * @param t
+     * @param errMsg
+     * @return
+     */
+    private RpcServerException createServerException(Throwable t, String errMsg) {
+        String formattedErrMsg = String.format("OriginErrMsg: %s: %s. AdditionalErrMsg: %s", t
+            .getClass().getName(), t.getMessage(), errMsg);
+        RpcServerException e = new RpcServerException(formattedErrMsg);
+        e.setStackTrace(t.getStackTrace());
+        return e;
     }
 }

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -116,20 +116,20 @@ public class RpcCommandFactory implements CommandFactory {
     }
 
     /**
-     * create server exception using error msg
-     * @param errMsg
-     * @return
+     * create server exception using error msg, no stack trace
+     * @param errMsg the assigned error message
+     * @return an instance of RpcServerException
      */
     private RpcServerException createServerException(String errMsg) {
         return new RpcServerException(errMsg);
     }
 
     /**
-     * create server exception using error msg and throwable.
+     * create server exception using error msg and fill the stack trace using the stack trace of throwable.
      *
      * @param t the origin throwable to fill the stack trace of rpc server exception
      * @param errMsg additional error msg, <code>null</code> is allowed
-     * @return
+     * @return an instance of RpcServerException
      */
     private RpcServerException createServerException(Throwable t, String errMsg) {
         String formattedErrMsg = String.format(

--- a/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcCommandFactory.java
@@ -131,8 +131,9 @@ public class RpcCommandFactory implements CommandFactory {
      * @return
      */
     private RpcServerException createServerException(Throwable t, String errMsg) {
-        String formattedErrMsg = String.format("OriginErrMsg: %s: %s. AdditionalErrMsg: %s", t
-            .getClass().getName(), t.getMessage(), errMsg);
+        String formattedErrMsg = String.format(
+            "[Server]OriginErrorMsg: %s: %s. AdditionalErrorMsg: %s", t.getClass().getName(),
+            t.getMessage(), errMsg);
         RpcServerException e = new RpcServerException(formattedErrMsg);
         e.setStackTrace(t.getStackTrace());
         return e;

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
@@ -173,17 +173,16 @@ public class RpcResponseResolver {
 
     /**
      * Detail your error msg with the error msg returned from response command
-     * @param originErrMsg
+     * @param clientErrMsg
      * @param responseCommand
      * @return
      */
-    private static String detailErrMsg(String originErrMsg, ResponseCommand responseCommand) {
+    private static String detailErrMsg(String clientErrMsg, ResponseCommand responseCommand) {
         RpcResponseCommand resp = (RpcResponseCommand) responseCommand;
         if (StringUtils.isNotBlank(resp.getErrorMsg())) {
-            return String.format("OriginErrorMsg:%s, AdditionalErrMsg:%s", originErrMsg,
-                resp.getErrorMsg());
+            return String.format("%s, ServerErrorMsg:%s", clientErrMsg, resp.getErrorMsg());
         } else {
-            return String.format("OriginErrorMsg:%s, AdditionalErrMsg:null", originErrMsg);
+            return String.format("%s, ServerErrorMsg:null", clientErrMsg);
         }
     }
 }

--- a/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcResponseResolver.java
@@ -52,19 +52,17 @@ public class RpcResponseResolver {
      */
     public static Object resolveResponseObject(ResponseCommand responseCommand, String addr)
                                                                                             throws RemotingException {
-
         preProcess(responseCommand, addr);
-
         if (responseCommand.getResponseStatus() == ResponseStatus.SUCCESS) {
             return toResponseObject(responseCommand);
         } else {
-            String msg = "Rpc invocation exception:" + responseCommand.getResponseStatus()
-                         + ", the address is " + addr + ", id=" + responseCommand.getId();
+            String msg = String.format("Rpc invocation exception: %s, the address is %s, id=%s",
+                responseCommand.getResponseStatus(), addr, responseCommand.getId());
             logger.warn(msg);
             if (responseCommand.getCause() != null) {
                 throw new InvokeException(msg, responseCommand.getCause());
             } else {
-                throw new InvokeException(msg + ", please check the server log.");
+                throw new InvokeException(msg + ", please check the server log for more.");
             }
         }
 
@@ -78,60 +76,64 @@ public class RpcResponseResolver {
      */
     private static void preProcess(ResponseCommand responseCommand, String addr)
                                                                                 throws RemotingException {
-
         RemotingException e = null;
         String msg = null;
         if (responseCommand == null) {
-            msg = "Rpc invocation timeout[responseCommand null]! the address is " + addr;
+            msg = String.format("Rpc invocation timeout[responseCommand null]! the address is %s",
+                addr);
             e = new InvokeTimeoutException(msg);
         } else {
             switch (responseCommand.getResponseStatus()) {
                 case TIMEOUT:
-                    msg = "Rpc invocation timeout[responseCommand TIMEOUT]! the address is " + addr;
+                    msg = String.format(
+                        "Rpc invocation timeout[responseCommand TIMEOUT]! the address is %s", addr);
                     e = new InvokeTimeoutException(msg);
                     break;
                 case CLIENT_SEND_ERROR:
-                    msg = "Rpc invocation send failed! the address is " + addr;
+                    msg = String.format("Rpc invocation send failed! the address is %s", addr);
                     e = new InvokeSendFailedException(msg, responseCommand.getCause());
                     break;
                 case CONNECTION_CLOSED:
-                    msg = "Connection closed! the address is " + addr;
+                    msg = String.format("Connection closed! the address is %s", addr);
                     e = new ConnectionClosedException(msg);
                     break;
                 case SERVER_THREADPOOL_BUSY:
-                    msg = "Server thread pool busy! the address is " + addr + ", id="
-                          + responseCommand.getId();
+                    msg = String.format("Server thread pool busy! the address is %s, id=%s", addr,
+                        responseCommand.getId());
                     e = new InvokeServerBusyException(msg);
                     break;
                 case CODEC_EXCEPTION:
-                    msg = "Codec exception! the address is " + addr + ", id="
-                          + responseCommand.getId();
+                    msg = String.format("Codec exception! the address is %s, id=%s", addr,
+                        responseCommand.getId());
                     e = new CodecException(msg);
                     break;
                 case SERVER_SERIAL_EXCEPTION:
-                    msg = "Server serialize response exception! the address is " + addr + ", id="
-                          + responseCommand.getId() + ", serverSide=true";
+                    msg = String
+                        .format(
+                            "Server serialize response exception! the address is %s, id=%s, serverSide=true",
+                            addr, responseCommand.getId());
                     e = new SerializationException(detailErrMsg(msg, responseCommand),
                         toThrowable(responseCommand), true);
                     break;
                 case SERVER_DESERIAL_EXCEPTION:
-                    msg = "Server deserialize request exception! the address is " + addr + ", id="
-                          + responseCommand.getId() + ", serverSide=true";
+                    msg = String
+                        .format(
+                            "Server deserialize request exception! the address is %s, id=%s, serverSide=true",
+                            addr, responseCommand.getId());
                     e = new DeserializationException(detailErrMsg(msg, responseCommand),
                         toThrowable(responseCommand), true);
                     break;
                 case SERVER_EXCEPTION:
-                    msg = "Server exception! Please check the server log, the address is " + addr
-                          + ", id=" + responseCommand.getId();
+                    msg = String.format(
+                        "Server exception! Please check the server log, the address is %s, id=%s",
+                        addr, responseCommand.getId());
                     e = new InvokeServerException(detailErrMsg(msg, responseCommand),
                         toThrowable(responseCommand));
                     break;
                 default:
                     break;
             }
-
         }
-
         if (StringUtils.isNotBlank(msg)) {
             logger.warn(msg);
         }

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
@@ -151,8 +151,8 @@ public class RpcCommandHandler implements CommandHandler {
             RequestCommand cmd = (RequestCommand) msg;
             if (cmd.getType() != RpcCommandType.REQUEST_ONEWAY) {
                 if (t instanceof RejectedExecutionException) {
-                    final ResponseCommand response = (ResponseCommand) this.commandFactory
-                        .createExceptionResponse(id, ResponseStatus.SERVER_THREADPOOL_BUSY);
+                    final ResponseCommand response = this.commandFactory.createExceptionResponse(
+                        id, ResponseStatus.SERVER_THREADPOOL_BUSY);
                     // RejectedExecutionException here assures no response has been sent back
                     // Other exceptions should be processed where exception was caught, because here we don't known whether ack had been sent back.  
                     ctx.getChannelContext().writeAndFlush(response)

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcRequestProcessor.java
@@ -164,7 +164,13 @@ public class RpcRequestProcessor extends AbstractRemotingProcessor<RpcRequestCom
                                 + id;
                 logger.error(errMsg, e);
                 serializedResponse = this.getCommandFactory().createExceptionResponse(id,
-                    ResponseStatus.SERVER_SERIAL_EXCEPTION);
+                    ResponseStatus.SERVER_SERIAL_EXCEPTION, e);
+                try {
+                    serializedResponse.serialize();// serialize again for exception response
+                } catch (SerializationException e1) {
+                    // should not happen
+                    logger.error("serialize SerializationException response failed!");
+                }
             } catch (Throwable t) {
                 String errMsg = "Serialize RpcResponseCommand failed when sendResponseIfNecessary in RpcRequestProcessor, id="
                                 + id;
@@ -269,7 +275,7 @@ public class RpcRequestProcessor extends AbstractRemotingProcessor<RpcRequestCom
                     "DeserializationException occurred when process in RpcRequestProcessor, id={}, deserializeLevel={}",
                     cmd.getId(), RpcDeserializeLevel.valueOf(level), e);
             sendResponseIfNecessary(ctx, cmd.getType(), this.getCommandFactory()
-                .createExceptionResponse(cmd.getId(), ResponseStatus.SERVER_DESERIAL_EXCEPTION));
+                .createExceptionResponse(cmd.getId(), ResponseStatus.SERVER_DESERIAL_EXCEPTION, e));
             result = false;
         } catch (Throwable t) {
             String errMsg = "Deserialize RpcRequestCommand failed in RpcRequestProcessor, id="


### PR DESCRIPTION
1. detail exception returned from server when serialize response failed or deserialize request failed (fix #22).
  > notice: this will increase the response size when exception occurs. @leizhiyuan plz help to review.
2. do some refactor about exception error msg, mainly use `String.format()` to optimize

## test
* Notice: this only detail exception returned from server, like `request deserialization exception` or `response serialization exception`. 
* `request serialization exception` and `response deserialization exception` keep the same as the previous version.
#### 1. request deserialization exception
* before this pr
```
2018-07-24 15:54:38,074 ERROR [ClassCustomSerializerTest#204] [main] 
com.alipay.remoting.exception.DeserializationException: Server deserialize request exception! the address is 127.0.0.1:60718, id=4, serverSide=true
	at com.alipay.remoting.rpc.RpcResponseResolver.preProcess(RpcResponseResolver.java:119) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcResponseResolver.resolveResponseObject(RpcResponseResolver.java:56) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:186) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClientRemoting.invokeSync(RpcClientRemoting.java:67) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:143) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClient.invokeSync(RpcClient.java:286) ~[classes/:?]
	at com.alipay.remoting.rpc.serializer.ClassCustomSerializerTest.testRequestDeserialException(ClassCustomSerializerTest.java:201) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_172]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_172]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_172]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_172]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) [junit-4.11.jar:?]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.11.jar:?]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:?]
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160) [junit-4.11.jar:?]
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70) [junit-rt.jar:?]
```
* after this pr
```
2018-07-24 15:47:30,540 ERROR [ClassCustomSerializerTest#204] [main] 
com.alipay.remoting.exception.DeserializationException: Server deserialize request exception! the address is 127.0.0.1:60506, id=4, serverSide=true, ServerErrorMsg:null
	at com.alipay.remoting.rpc.RpcResponseResolver.preProcess(RpcResponseResolver.java:124) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcResponseResolver.resolveResponseObject(RpcResponseResolver.java:55) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:186) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClientRemoting.invokeSync(RpcClientRemoting.java:67) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:143) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClient.invokeSync(RpcClient.java:290) ~[classes/:?]
	at com.alipay.remoting.rpc.serializer.ClassCustomSerializerTest.testRequestDeserialException(ClassCustomSerializerTest.java:201) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_172]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_172]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_172]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_172]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) [junit-4.11.jar:?]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.11.jar:?]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:?]
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160) [junit-4.11.jar:?]
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70) [junit-rt.jar:?]
Caused by: com.alipay.remoting.rpc.exception.RpcServerException: [Server]OriginErrorMsg: com.alipay.remoting.exception.DeserializationException: deserialException in ExceptionRequestBodyCustomSerializer!. AdditionalErrorMsg: null
	at com.alipay.remoting.rpc.serializer.ExceptionRequestBodyCustomSerializer.deserializeContent(ExceptionRequestBodyCustomSerializer.java:88) ~[test-classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestCommand.deserializeContent(RpcRequestCommand.java:144) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcCommand.deserialize(RpcCommand.java:117) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcCommand.deserialize(RpcCommand.java:138) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.deserializeRequestCommand(RpcRequestProcessor.java:270) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.doProcess(RpcRequestProcessor.java:142) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor$ProcessTask.run(RpcRequestProcessor.java:377) ~[classes/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_172]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_172]
```

#### 2. response serialization exception
* before this pr
```
2018-07-24 15:54:37,921 ERROR [ClassCustomSerializerTest#265] [main] 
com.alipay.remoting.exception.SerializationException: Server serialize response exception! the address is 127.0.0.1:60716, id=3, serverSide=true
	at com.alipay.remoting.rpc.RpcResponseResolver.preProcess(RpcResponseResolver.java:114) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcResponseResolver.resolveResponseObject(RpcResponseResolver.java:56) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:186) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClientRemoting.invokeSync(RpcClientRemoting.java:67) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:143) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClient.invokeSync(RpcClient.java:286) ~[classes/:?]
	at com.alipay.remoting.rpc.serializer.ClassCustomSerializerTest.testResponseSerialException(ClassCustomSerializerTest.java:262) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_172]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_172]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_172]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_172]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) [junit-4.11.jar:?]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.11.jar:?]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:?]
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160) [junit-4.11.jar:?]
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70) [junit-rt.jar:?]
```

* after this pr
```
2018-07-24 15:47:30,420 ERROR [ClassCustomSerializerTest#265] [main] 
com.alipay.remoting.exception.SerializationException: Server serialize response exception! the address is 127.0.0.1:60504, id=3, serverSide=true, ServerErrorMsg:null
	at com.alipay.remoting.rpc.RpcResponseResolver.preProcess(RpcResponseResolver.java:116) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcResponseResolver.resolveResponseObject(RpcResponseResolver.java:55) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:186) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClientRemoting.invokeSync(RpcClientRemoting.java:67) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcRemoting.invokeSync(RpcRemoting.java:143) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcClient.invokeSync(RpcClient.java:290) ~[classes/:?]
	at com.alipay.remoting.rpc.serializer.ClassCustomSerializerTest.testResponseSerialException(ClassCustomSerializerTest.java:262) [test-classes/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_172]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_172]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_172]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_172]
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47) [junit-4.11.jar:?]
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12) [junit-4.11.jar:?]
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26) [junit-4.11.jar:?]
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70) [junit-4.11.jar:?]
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229) [junit-4.11.jar:?]
	at org.junit.runners.ParentRunner.run(ParentRunner.java:309) [junit-4.11.jar:?]
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160) [junit-4.11.jar:?]
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242) [junit-rt.jar:?]
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70) [junit-rt.jar:?]
Caused by: com.alipay.remoting.rpc.exception.RpcServerException: [Server]OriginErrorMsg: com.alipay.remoting.exception.SerializationException: serialException in ExceptionStringCustomSerializer!. AdditionalErrorMsg: null
	at com.alipay.remoting.rpc.serializer.ExceptionStringCustomSerializer.serializeContent(ExceptionStringCustomSerializer.java:67) ~[test-classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcResponseCommand.serializeContent(RpcResponseCommand.java:109) ~[classes/:?]
	at com.alipay.remoting.rpc.RpcCommand.serialize(RpcCommand.java:105) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.sendResponseIfNecessary(RpcRequestProcessor.java:161) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.dispatchToUserProcessor(RpcRequestProcessor.java:243) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor.doProcess(RpcRequestProcessor.java:145) ~[classes/:?]
	at com.alipay.remoting.rpc.protocol.RpcRequestProcessor$ProcessTask.run(RpcRequestProcessor.java:377) ~[classes/:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[?:1.8.0_172]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[?:1.8.0_172]
	at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_172]
```