### PR TITLE
(feature) RPC 层支持从 IO 线程派发 mesage list

### DIFF
--- a/src/main/java/com/alipay/remoting/config/ConfigManager.java
+++ b/src/main/java/com/alipay/remoting/config/ConfigManager.java
@@ -152,20 +152,20 @@ public class ConfigManager {
         return getByte(Configs.SERIALIZER, Configs.SERIALIZER_DEFAULT);
     }
 
-    // ~~~ private methods
-    protected static boolean getBool(String key, String defaultValue) {
+    // ~~~ public helper methods to retrieve system property
+    public static boolean getBool(String key, String defaultValue) {
         return Boolean.parseBoolean(System.getProperty(key, defaultValue));
     }
 
-    protected static int getInt(String key, String defaultValue) {
+    public static int getInt(String key, String defaultValue) {
         return Integer.parseInt(System.getProperty(key, defaultValue));
     }
 
-    protected static byte getByte(String key, String defaultValue) {
+    public static byte getByte(String key, String defaultValue) {
         return Byte.parseByte(System.getProperty(key, defaultValue));
     }
 
-    protected static long getLong(String key, String defaultValue) {
+    public static long getLong(String key, String defaultValue) {
         return Long.parseLong(System.getProperty(key, defaultValue));
     }
 }

--- a/src/main/java/com/alipay/remoting/rpc/RpcConfigManager.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConfigManager.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc;
+
+import com.alipay.remoting.config.ConfigManager;
+
+/**
+ * RPC framework config manager.
+ * @author dennis
+ * 
+ *
+ */
+public class RpcConfigManager {
+    public static boolean dispatch_msg_list_in_default_executor() {
+        return ConfigManager.getBool(RpcConfigs.DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR,
+            RpcConfigs.DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR_DEFAULT);
+    }
+}

--- a/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConfigs.java
@@ -26,25 +26,31 @@ public class RpcConfigs {
     /**
      * Protocol key in url.
      */
-    public static final String URL_PROTOCOL          = "_PROTOCOL";
+    public static final String URL_PROTOCOL                                  = "_PROTOCOL";
 
     /**
      * Version key in url.
      */
-    public static final String URL_VERSION           = "_VERSION";
+    public static final String URL_VERSION                                   = "_VERSION";
 
     /**
      * Connection timeout key in url.
      */
-    public static final String CONNECT_TIMEOUT_KEY   = "_CONNECTTIMEOUT";
+    public static final String CONNECT_TIMEOUT_KEY                           = "_CONNECTTIMEOUT";
 
     /**
      * Connection number key of each address
      */
-    public static final String CONNECTION_NUM_KEY    = "_CONNECTIONNUM";
+    public static final String CONNECTION_NUM_KEY                            = "_CONNECTIONNUM";
 
     /**
      * whether need to warm up connections
      */
-    public static final String CONNECTION_WARMUP_KEY = "_CONNECTIONWARMUP";
+    public static final String CONNECTION_WARMUP_KEY                         = "_CONNECTIONWARMUP";
+
+    /**
+     * Whether to dispatch message list in default executor.
+     */
+    public static final String DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR         = "bolt.rpc.dispatch-msg-list-in-default-executor";
+    public static final String DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR_DEFAULT = "true";
 }

--- a/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
+++ b/src/main/java/com/alipay/remoting/rpc/protocol/RpcCommandHandler.java
@@ -37,6 +37,7 @@ import com.alipay.remoting.rpc.RequestCommand;
 import com.alipay.remoting.rpc.ResponseCommand;
 import com.alipay.remoting.rpc.RpcCommand;
 import com.alipay.remoting.rpc.RpcCommandType;
+import com.alipay.remoting.rpc.RpcConfigManager;
 
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -96,24 +97,29 @@ public class RpcCommandHandler implements CommandHandler {
      */
     private void handle(final RemotingContext ctx, final Object msg) {
         try {
-            // If msg is list ,then the batch submission to biz threadpool can save io thread.
-            // See com.alipay.remoting.decoder.ProtocolDecoder
             if (msg instanceof List) {
-                processorManager.getDefaultExecutor().execute(new Runnable() {
+                final Runnable handleTask = new Runnable() {
                     @Override
                     public void run() {
                         if (logger.isDebugEnabled()) {
                             logger.debug("Batch message! size={}", ((List<?>) msg).size());
                         }
-                        for (Object m : (List<?>) msg) {
+                        for (final Object m : (List<?>) msg) {
                             RpcCommandHandler.this.process(ctx, m);
                         }
                     }
-                });
+                };
+                if (RpcConfigManager.dispatch_msg_list_in_default_executor()) {
+                    // If msg is list ,then the batch submission to biz threadpool can save io thread.
+                    // See com.alipay.remoting.decoder.ProtocolDecoder
+                    processorManager.getDefaultExecutor().execute(handleTask);
+                } else {
+                    handleTask.run();
+                }
             } else {
                 process(ctx, msg);
             }
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             processException(ctx, msg, t);
         }
     }
@@ -121,17 +127,17 @@ public class RpcCommandHandler implements CommandHandler {
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private void process(RemotingContext ctx, Object msg) {
         try {
-            RpcCommand cmd = (RpcCommand) msg;
-            RemotingProcessor processor = processorManager.getProcessor(cmd.getCmdCode());
+            final RpcCommand cmd = (RpcCommand) msg;
+            final RemotingProcessor processor = processorManager.getProcessor(cmd.getCmdCode());
             processor.process(ctx, cmd, processorManager.getDefaultExecutor());
-        } catch (Throwable t) {
+        } catch (final Throwable t) {
             processException(ctx, msg, t);
         }
     }
 
     private void processException(RemotingContext ctx, Object msg, Throwable t) {
         if (msg instanceof List) {
-            for (Object m : (List<?>) msg) {
+            for (final Object m : (List<?>) msg) {
                 processExceptionForSingleCommand(ctx, m, t);
             }
         } else {
@@ -144,17 +150,17 @@ public class RpcCommandHandler implements CommandHandler {
      */
     private void processExceptionForSingleCommand(RemotingContext ctx, Object msg, Throwable t) {
         final int id = ((RpcCommand) msg).getId();
-        String emsg = "Exception caught when processing "
-                      + ((msg instanceof RequestCommand) ? "request, id=" : "response, id=");
+        final String emsg = "Exception caught when processing "
+                            + ((msg instanceof RequestCommand) ? "request, id=" : "response, id=");
         logger.warn(emsg + id, t);
         if (msg instanceof RequestCommand) {
-            RequestCommand cmd = (RequestCommand) msg;
+            final RequestCommand cmd = (RequestCommand) msg;
             if (cmd.getType() != RpcCommandType.REQUEST_ONEWAY) {
                 if (t instanceof RejectedExecutionException) {
                     final ResponseCommand response = this.commandFactory.createExceptionResponse(
                         id, ResponseStatus.SERVER_THREADPOOL_BUSY);
                     // RejectedExecutionException here assures no response has been sent back
-                    // Other exceptions should be processed where exception was caught, because here we don't known whether ack had been sent back.  
+                    // Other exceptions should be processed where exception was caught, because here we don't known whether ack had been sent back.
                     ctx.getChannelContext().writeAndFlush(response)
                         .addListener(new ChannelFutureListener() {
                             @Override
@@ -179,7 +185,7 @@ public class RpcCommandHandler implements CommandHandler {
         }
     }
 
-    /** 
+    /**
      * @see CommandHandler#registerProcessor(com.alipay.remoting.CommandCode, RemotingProcessor)
      */
     @Override
@@ -188,7 +194,7 @@ public class RpcCommandHandler implements CommandHandler {
         this.processorManager.registerProcessor(cmd, processor);
     }
 
-    /** 
+    /**
      * @see CommandHandler#registerDefaultExecutor(java.util.concurrent.ExecutorService)
      */
     @Override
@@ -196,7 +202,7 @@ public class RpcCommandHandler implements CommandHandler {
         this.processorManager.registerDefaultExecutor(executor);
     }
 
-    /** 
+    /**
      * @see CommandHandler#getDefaultExecutor()
      */
     @Override

--- a/src/test/java/com/alipay/remoting/rpc/RpcConfigManagerTest.java
+++ b/src/test/java/com/alipay/remoting/rpc/RpcConfigManagerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.rpc;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RpcConfigManagerTest {
+    @BeforeClass
+    public static void initClass() {
+    }
+
+    @Before
+    public void init() {
+    }
+
+    @After
+    public void stop() {
+    }
+
+    @AfterClass
+    public static void afterClass() {
+    }
+
+    @Test
+    public void testSystemSettings() {
+        Assert.assertTrue(RpcConfigManager.dispatch_msg_list_in_default_executor());
+    }
+}


### PR DESCRIPTION
主要改动如下：

1. 新增 `RpcConfigManager` 类用于 RPC 层的配置管理。
2. 新增 `RpcConfigs.DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR` 和 `DISPATCH_MSG_LIST_IN_DEFAULT_EXECUTOR_DEFAULT` 表示是否使用 default executor 派发 msg list ，默认为 `true`，兼容当前行为。
3. 当 `bolt.rpc.dispatch-msg-list-in-default-executor` 为 false 的时候，将从 io 线程派发 msg list。修改 `RpcCommandHandler#handle(final RemotingContext ctx, final Object msg)` 逻辑。


