### PR TITLE
clean code

### DIFF
--- a/src/main/java/com/alipay/remoting/AsyncContext.java
+++ b/src/main/java/com/alipay/remoting/AsyncContext.java
@@ -28,5 +28,5 @@ public interface AsyncContext {
      * 
      * @param responseObject
      */
-    public void sendResponse(Object responseObject);
+    void sendResponse(Object responseObject);
 }

--- a/src/main/java/com/alipay/remoting/CommonCommandCode.java
+++ b/src/main/java/com/alipay/remoting/CommonCommandCode.java
@@ -28,7 +28,7 @@ public enum CommonCommandCode implements CommandCode {
 
     private short value;
 
-    private CommonCommandCode(short value) {
+    CommonCommandCode(short value) {
         this.value = value;
     }
 

--- a/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
+++ b/src/main/java/com/alipay/remoting/ConnectionEventProcessor.java
@@ -28,5 +28,5 @@ public interface ConnectionEventProcessor {
      * @param remoteAddr
      * @param conn
      */
-    public void onEvent(String remoteAddr, Connection conn);
+    void onEvent(String remoteAddr, Connection conn);
 }

--- a/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
+++ b/src/main/java/com/alipay/remoting/ConnectionMonitorStrategy.java
@@ -34,7 +34,7 @@ public interface ConnectionMonitorStrategy {
      *
      * @param connections
      */
-    public Map<String, List<Connection>> filter(List<Connection> connections);
+    Map<String, List<Connection>> filter(List<Connection> connections);
 
     /**
      * Add a set of connections to monitor.
@@ -44,5 +44,5 @@ public interface ConnectionMonitorStrategy {
      *
      * @param connPools
      */
-    public void monitor(Map<String, RunStateRecordedFutureTask<ConnectionPool>> connPools);
+    void monitor(Map<String, RunStateRecordedFutureTask<ConnectionPool>> connPools);
 }

--- a/src/main/java/com/alipay/remoting/InvokeContext.java
+++ b/src/main/java/com/alipay/remoting/InvokeContext.java
@@ -85,6 +85,7 @@ public class InvokeContext {
      * @param key
      * @return
      */
+    @SuppressWarnings("unchecked")
     public <T> T get(String key) {
         return (T) this.context.get(key);
     }
@@ -97,6 +98,7 @@ public class InvokeContext {
      * @param <T>
      * @return
      */
+    @SuppressWarnings("unchecked")
     public <T> T get(String key, T defaultIfNotFound) {
         return this.context.get(key) != null ? (T) this.context.get(key) : defaultIfNotFound;
     }

--- a/src/main/java/com/alipay/remoting/RemotingCommand.java
+++ b/src/main/java/com/alipay/remoting/RemotingCommand.java
@@ -99,5 +99,5 @@ public interface RemotingCommand extends Serializable {
      * @param invokeContext
      * @throws DeserializationException
      */
-    void deserializeContent(InvokeContext invokeContext) throws DeserializationException;;
+    void deserializeContent(InvokeContext invokeContext) throws DeserializationException;
 }

--- a/src/main/java/com/alipay/remoting/config/configs/DefaultConfigContainer.java
+++ b/src/main/java/com/alipay/remoting/config/configs/DefaultConfigContainer.java
@@ -42,11 +42,12 @@ public class DefaultConfigContainer implements ConfigContainer {
     @Override
     public boolean contains(ConfigType configType, ConfigItem configItem) {
         validate(configType, configItem);
-        return null != userConfigs.get(configType) ? userConfigs.get(configType).containsKey(
-            configItem) : false;
+        return null != userConfigs.get(configType)
+               && userConfigs.get(configType).containsKey(configItem);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T get(ConfigType configType, ConfigItem configItem) {
         validate(configType, configItem);
         if (userConfigs.containsKey(configType)) {

--- a/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcConnectionFactory.java
@@ -19,7 +19,6 @@ package com.alipay.remoting.rpc;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.alipay.remoting.config.ConfigurableInstance;
-import com.alipay.remoting.connection.ConnectionFactory;
 import com.alipay.remoting.connection.DefaultConnectionFactory;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
 
@@ -28,7 +27,7 @@ import com.alipay.remoting.rpc.protocol.UserProcessor;
  *
  * @author chengyi (mark.lx@antfin.com) 2018-06-20 15:32
  */
-public class RpcConnectionFactory extends DefaultConnectionFactory implements ConnectionFactory {
+public class RpcConnectionFactory extends DefaultConnectionFactory {
 
     public RpcConnectionFactory(ConcurrentHashMap<String, UserProcessor<?>> userProcessors,
                                 ConfigurableInstance configInstance) {


### PR DESCRIPTION
1、去除接口中方法的public修饰符
2、去除枚举类的构造器的private修饰符
3、简化DefaultConfigContainer中含有null判断的三目运算符
4、添加类型转换unchecked警告压制注解
5、去除重复的接口实现
RpcConnectionFactory extends DefaultConnectionFactory implements ConnectionFactory（这里的接口实现重复）
DefaultConnectionFactory extends AbstractConnectionFactory
AbstractConnectionFactory implements ConnectionFactory