### PR TITLE
Refactor RpcClient with LifeCycle interface and add option module

### DIFF
--- a/src/main/java/com/alipay/remoting/AbstractBoltClient.java
+++ b/src/main/java/com/alipay/remoting/AbstractBoltClient.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting;
+
+import com.alipay.remoting.config.BoltOption;
+import com.alipay.remoting.config.BoltOptions;
+import com.alipay.remoting.config.ConfigManager;
+import com.alipay.remoting.config.Configurable;
+import com.alipay.remoting.config.ConfigurableInstance;
+import com.alipay.remoting.config.configs.ConfigContainer;
+import com.alipay.remoting.config.configs.ConfigItem;
+import com.alipay.remoting.config.configs.ConfigType;
+import com.alipay.remoting.config.configs.DefaultConfigContainer;
+import com.alipay.remoting.config.switches.GlobalSwitch;
+
+/**
+ * @author chengyi (mark.lx@antfin.com) 2018-11-07 15:22
+ */
+public abstract class AbstractBoltClient extends AbstractLifeCycle implements BoltClient,
+                                                                  ConfigurableInstance {
+
+    private final BoltOptions     options;
+    private final ConfigType      configType;
+    private final GlobalSwitch    globalSwitch;
+    private final ConfigContainer configContainer;
+
+    public AbstractBoltClient() {
+        this.options = new BoltOptions();
+        this.configType = ConfigType.CLIENT_SIDE;
+        this.globalSwitch = new GlobalSwitch();
+        this.configContainer = new DefaultConfigContainer();
+    }
+
+    @Override
+    public <T> T option(BoltOption<T> option) {
+        return options.option(option);
+    }
+
+    @Override
+    public <T> Configurable option(BoltOption<T> option, T value) {
+        options.option(option, value);
+        return this;
+    }
+
+    @Override
+    public ConfigContainer conf() {
+        return this.configContainer;
+    }
+
+    @Override
+    public GlobalSwitch switches() {
+        return this.globalSwitch;
+    }
+
+    @Override
+    public void initWriteBufferWaterMark(int low, int high) {
+        this.configContainer.set(configType, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK, low);
+        this.configContainer.set(configType, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK, high);
+    }
+
+    @Override
+    public int netty_buffer_low_watermark() {
+        if (configContainer.contains(configType, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK)) {
+            return (Integer) configContainer
+                .get(configType, ConfigItem.NETTY_BUFFER_LOW_WATER_MARK);
+        } else {
+            return ConfigManager.netty_buffer_low_watermark();
+        }
+    }
+
+    @Override
+    public int netty_buffer_high_watermark() {
+        if (configContainer.contains(configType, ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK)) {
+            return (Integer) configContainer.get(configType,
+                ConfigItem.NETTY_BUFFER_HIGH_WATER_MARK);
+        } else {
+            return ConfigManager.netty_buffer_high_watermark();
+        }
+    }
+}

--- a/src/main/java/com/alipay/remoting/BoltClient.java
+++ b/src/main/java/com/alipay/remoting/BoltClient.java
@@ -1,0 +1,657 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting;
+
+import com.alipay.remoting.config.Configurable;
+import com.alipay.remoting.exception.RemotingException;
+import com.alipay.remoting.rpc.RpcClient;
+import com.alipay.remoting.rpc.RpcConfigs;
+import com.alipay.remoting.rpc.RpcResponseFuture;
+import com.alipay.remoting.rpc.protocol.UserProcessor;
+import com.alipay.remoting.rpc.protocol.UserProcessorRegisterHelper;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bolt client interface.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-07 11:56
+ */
+public interface BoltClient extends Configurable, LifeCycle {
+
+    /**
+     * One way invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
+     *   </ol>
+     *
+     * @param address target address
+     * @param request request
+     */
+    void oneway(final String address, final Object request) throws RemotingException,
+                                                           InterruptedException;
+
+    /**
+     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Connection, Object)}
+     *
+     * @param address target address
+     * @param request request
+     * @param invokeContext invoke context
+     */
+    void oneway(final String address, final Object request, final InvokeContext invokeContext)
+                                                                                              throws RemotingException,
+                                                                                              InterruptedException;
+
+    /**
+     * One way invocation using a parsed {@link Url} <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
+     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
+     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
+     *   </ol>
+     *
+     * @param url target url
+     * @param request object
+     */
+    void oneway(final Url url, final Object request) throws RemotingException, InterruptedException;
+
+    /**
+     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Url, Object)}
+     *
+     * @param url url
+     * @param request request
+     * @param invokeContext invoke context
+     */
+    void oneway(final Url url, final Object request, final InvokeContext invokeContext)
+                                                                                       throws RemotingException,
+                                                                                       InterruptedException;
+
+    /**
+     * One way invocation using a {@link Connection} <br>
+     * <p>
+     * Notice:<br>
+     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
+     *
+     * @param conn target connection
+     * @param request request
+     */
+    void oneway(final Connection conn, final Object request) throws RemotingException;
+
+    /**
+     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Connection, Object)}
+     *
+     * @param conn target connection
+     * @param request request
+     * @param invokeContext invoke context
+     */
+    void oneway(final Connection conn, final Object request, final InvokeContext invokeContext)
+                                                                                               throws RemotingException;
+
+    /**
+     * Synchronous invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
+     *   </ol>
+     *
+     * @param address target address
+     * @param request request
+     * @param timeoutMillis timeout millisecond
+     * @return result object
+     */
+    Object invokeSync(final String address, final Object request, final int timeoutMillis)
+                                                                                          throws RemotingException,
+                                                                                          InterruptedException;
+
+    /**
+     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(String, Object, int)}
+     *
+     * @param address target address
+     * @param request request
+     * @param invokeContext invoke context
+     * @param timeoutMillis timeout in millisecond
+     * @return result object
+     */
+    Object invokeSync(final String address, final Object request,
+                      final InvokeContext invokeContext, final int timeoutMillis)
+                                                                                 throws RemotingException,
+                                                                                 InterruptedException;
+
+    /**
+     * Synchronous invocation using a parsed {@link Url} <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
+     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
+     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
+     *   </ol>
+     *
+     * @param url target url
+     * @param request request
+     * @param timeoutMillis timeout in millisecond
+     * @return Object
+     */
+    Object invokeSync(final Url url, final Object request, final int timeoutMillis)
+                                                                                   throws RemotingException,
+                                                                                   InterruptedException;
+
+    /**
+     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(Url, Object, int)}
+     *
+     * @param url target url
+     * @param request request
+     * @param invokeContext invoke context
+     * @param timeoutMillis timeout in millisecond
+     * @return result object
+     */
+    Object invokeSync(final Url url, final Object request, final InvokeContext invokeContext,
+                      final int timeoutMillis) throws RemotingException, InterruptedException;
+
+    /**
+     * Synchronous invocation using a {@link Connection} <br>
+     * <p>
+     * Notice:<br>
+     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
+     *
+     * @param conn target connection
+     * @param request request
+     * @param timeoutMillis timeout in millisecond
+     * @return Object
+     */
+    Object invokeSync(final Connection conn, final Object request, final int timeoutMillis)
+                                                                                           throws RemotingException,
+                                                                                           InterruptedException;
+
+    /**
+     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(Connection, Object, int)}
+     *
+     * @param conn target connection
+     * @param request request
+     * @param invokeContext invoke context
+     * @param timeoutMillis timeout in millis
+     * @return Object
+     */
+    Object invokeSync(final Connection conn, final Object request,
+                      final InvokeContext invokeContext, final int timeoutMillis)
+                                                                                 throws RemotingException,
+                                                                                 InterruptedException;
+
+    /**
+     * Future invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
+     * You can get result use the returned {@link RpcResponseFuture}.
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
+     *   </ol>
+     *
+     * @param address target address
+     * @param request request
+     * @param timeoutMillis timeout in millisecond
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final String address, final Object request,
+                                       final int timeoutMillis) throws RemotingException,
+                                                               InterruptedException;
+
+    /**
+     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(String, Object, int)}
+     *
+     * @param address target address
+     * @param request request
+     * @param invokeContext invoke context
+     * @param timeoutMillis timeout in millisecond
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final String address, final Object request,
+                                       final InvokeContext invokeContext, final int timeoutMillis)
+                                                                                                  throws RemotingException,
+                                                                                                  InterruptedException;
+
+    /**
+     * Future invocation using a parsed {@link Url} <br>
+     * You can get result use the returned {@link RpcResponseFuture}.
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
+     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
+     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
+     *   </ol>
+     *
+     * @param url target url
+     * @param request request
+     * @param timeoutMillis timeout in millisecond
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final Url url, final Object request, final int timeoutMillis)
+                                                                                                    throws RemotingException,
+                                                                                                    InterruptedException;
+
+    /**
+     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(Url, Object, int)}
+     *
+     * @param url target url
+     * @param request request
+     * @param invokeContext invoke context
+     * @param timeoutMillis timeout in millis
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final Url url, final Object request,
+                                       final InvokeContext invokeContext, final int timeoutMillis)
+                                                                                                  throws RemotingException,
+                                                                                                  InterruptedException;
+
+    /**
+     * Future invocation using a {@link Connection} <br>
+     * You can get result use the returned {@link RpcResponseFuture}.
+     * <p>
+     * Notice:<br>
+     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
+     *
+     * @param conn target connection
+     * @param request request
+     * @param timeoutMillis timeout in millis
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final Connection conn, final Object request,
+                                       int timeoutMillis) throws RemotingException;
+
+    /**
+     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(Connection, Object, int)}
+     *
+     * @param conn target connection
+     * @param request request
+     * @param invokeContext context
+     * @param timeoutMillis timeout millisecond
+     * @return RpcResponseFuture
+     */
+    RpcResponseFuture invokeWithFuture(final Connection conn, final Object request,
+                                       final InvokeContext invokeContext, int timeoutMillis)
+                                                                                            throws RemotingException;
+
+    /**
+     * Callback invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
+     * You can specify an implementation of {@link InvokeCallback} to get the result.
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
+     *   </ol>
+     *
+     * @param addr target address
+     * @param request request
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final String addr, final Object request,
+                            final InvokeCallback invokeCallback, final int timeoutMillis)
+                                                                                         throws RemotingException,
+                                                                                         InterruptedException;
+
+    /**
+     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(String, Object, InvokeCallback, int)}
+     *
+     * @param addr target address
+     * @param request request
+     * @param invokeContext context
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final String addr, final Object request,
+                            final InvokeContext invokeContext, final InvokeCallback invokeCallback,
+                            final int timeoutMillis) throws RemotingException, InterruptedException;
+
+    /**
+     * Callback invocation using a parsed {@link Url} <br>
+     * You can specify an implementation of {@link InvokeCallback} to get the result.
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
+     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li>
+     *      <ul>
+     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
+     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
+     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
+     *      </ul>
+     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
+     *   </ol>
+     *
+     * @param url target url
+     * @param request request
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final Url url, final Object request,
+                            final InvokeCallback invokeCallback, final int timeoutMillis)
+                                                                                         throws RemotingException,
+                                                                                         InterruptedException;
+
+    /**
+     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(Url, Object, InvokeCallback, int)}
+     *
+     * @param url target url
+     * @param request request
+     * @param invokeContext context
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final Url url, final Object request, final InvokeContext invokeContext,
+                            final InvokeCallback invokeCallback, final int timeoutMillis)
+                                                                                         throws RemotingException,
+                                                                                         InterruptedException;
+
+    /**
+     * Callback invocation using a {@link Connection} <br>
+     * You can specify an implementation of {@link InvokeCallback} to get the result.
+     * <p>
+     * Notice:<br>
+     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
+     *
+     * @param conn target connection
+     * @param request request
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final Connection conn, final Object request,
+                            final InvokeCallback invokeCallback, final int timeoutMillis)
+                                                                                         throws RemotingException;
+
+    /**
+     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(Connection, Object, InvokeCallback, int)}
+     *
+     * @param conn target connection
+     * @param request request
+     * @param invokeContext invoke context
+     * @param invokeCallback callback
+     * @param timeoutMillis timeout in millisecond
+     */
+    void invokeWithCallback(final Connection conn, final Object request,
+                            final InvokeContext invokeContext, final InvokeCallback invokeCallback,
+                            final int timeoutMillis) throws RemotingException;
+
+    /**
+     * Add processor to process connection event.
+     *
+     * @param type connection event type
+     * @param processor connection event process
+     */
+    void addConnectionEventProcessor(ConnectionEventType type, ConnectionEventProcessor processor);
+
+    /**
+     * Use UserProcessorRegisterHelper{@link UserProcessorRegisterHelper} to help register user processor for client side.
+     */
+    void registerUserProcessor(UserProcessor<?> processor);
+
+    /**
+     * Create a stand alone connection using ip and port. <br>
+     * <p>
+     * Notice:<br>
+     *   <li>Each time you call this method, will create a new connection.
+     *   <li>Bolt will not control this connection.
+     *   <li>You should use {@link #closeStandaloneConnection} to close it.
+     *
+     * @param ip ip
+     * @param port port
+     * @param connectTimeout timeout in millisecond
+     */
+    Connection createStandaloneConnection(String ip, int port, int connectTimeout)
+                                                                                  throws RemotingException;
+
+    /**
+     * Create a stand alone connection using address, address format example - 127.0.0.1:12200 <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li>Each time you can this method, will create a new connection.
+     *   <li>Bolt will not control this connection.
+     *   <li>You should use {@link #closeStandaloneConnection} to close it.
+     *   </ol>
+     *
+     * @param address target address
+     * @param connectTimeout timeout in millisecond
+     */
+    Connection createStandaloneConnection(String address, int connectTimeout)
+                                                                             throws RemotingException;
+
+    /**
+     * Close a standalone connection
+     *
+     * @param conn target connection
+     */
+    void closeStandaloneConnection(Connection conn);
+
+    /**
+     * Get a connection using address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
+     * <p>
+     * Notice:<br>
+     *   <ol>
+     *   <li>Get a connection, if none then create.</li>
+     *      <ul>
+     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
+     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
+     *      </ul>
+     *   <li>Bolt will control this connection in {@link ConnectionPool}
+     *   <li>You should use {@link #closeConnection(String addr)} to close it.
+     *   </ol>
+     * @param addr target address
+     * @param connectTimeout this is prior to url args {@link RpcConfigs#CONNECT_TIMEOUT_KEY}
+     */
+    Connection getConnection(String addr, int connectTimeout) throws RemotingException,
+                                                             InterruptedException;
+
+    /**
+     * Get a connection using a {@link Url}.<br>
+     * <p>
+     * Notice:
+     *   <ol>
+     *   <li>Get a connection, if none then create.
+     *   <li>Bolt will control this connection in {@link com.alipay.remoting.ConnectionPool}
+     *   <li>You should use {@link #closeConnection(Url url)} to close it.
+     *   </ol>
+     *
+     * @param url target url
+     * @param connectTimeout this is prior to url args {@link RpcConfigs#CONNECT_TIMEOUT_KEY}
+     */
+    Connection getConnection(Url url, int connectTimeout) throws RemotingException,
+                                                         InterruptedException;
+
+    /**
+     * get all connections managed by rpc client
+     *
+     * @return map key is ip+port, value is a list of connections of this key.
+     */
+    Map<String, List<Connection>> getAllManagedConnections();
+
+    /**
+     * check connection, the address format example - 127.0.0.1:12200?key1=value1&key2=value2
+     *
+     * @param address target address
+     * @return true if and only if there is a connection, and the connection is active and writable;else return false
+     */
+    boolean checkConnection(String address);
+
+    /**
+     * Close all connections of a address
+     *
+     * @param address target address
+     */
+    void closeConnection(String address);
+
+    /**
+     * Close all connections of a {@link Url}
+     *
+     * @param url target url
+     */
+    void closeConnection(Url url);
+
+    /**
+     * Enable heart beat for a certain connection.
+     * If this address not connected, then do nothing.
+     * <p>
+     * Notice: this method takes no effect on a stand alone connection.
+     *
+     * @param address target address
+     */
+    void enableConnHeartbeat(String address);
+
+    /**
+     * Enable heart beat for a certain connection.
+     * If this {@link Url} not connected, then do nothing.
+     * <p>
+     * Notice: this method takes no effect on a stand alone connection.
+     *
+     * @param url target url
+     */
+    void enableConnHeartbeat(Url url);
+
+    /**
+     * Disable heart beat for a certain connection.
+     * If this addr not connected, then do nothing.
+     * <p>
+     * Notice: this method takes no effect on a stand alone connection.
+     *
+     * @param address target address
+     */
+    void disableConnHeartbeat(String address);
+
+    /**
+     * Disable heart beat for a certain connection.
+     * If this {@link Url} not connected, then do nothing.
+     * <p>
+     * Notice: this method takes no effect on a stand alone connection.
+     *
+     * @param url target url
+     */
+    void disableConnHeartbeat(Url url);
+
+    /**
+     * enable connection reconnect switch on
+     * <p>
+     * Notice: This api should be called before {@link RpcClient#init()}
+     */
+    void enableReconnectSwitch();
+
+    /**
+     * disable connection reconnect switch off
+     * <p>
+     * Notice: This api should be called before {@link RpcClient#init()}
+     */
+    void disableReconnectSwith();
+
+    /**
+     * is reconnect switch on
+     */
+    boolean isReconnectSwitchOn();
+
+    /**
+     * enable connection monitor switch on
+     */
+    void enableConnectionMonitorSwitch();
+
+    /**
+     * disable connection monitor switch off
+     * <p>
+     * Notice: This api should be called before {@link RpcClient#init()}
+     */
+    void disableConnectionMonitorSwitch();
+
+    /**
+     * is connection monitor switch on
+     */
+    boolean isConnectionMonitorSwitchOn();
+
+    /**
+     * Getter method for property <tt>connectionManager</tt>.
+     *
+     * @return property value of connectionManager
+     */
+    DefaultConnectionManager getConnectionManager();
+
+    /**
+     * Getter method for property <tt>addressParser</tt>.
+     *
+     * @return property value of addressParser
+     */
+    RemotingAddressParser getAddressParser();
+
+    /**
+     * Setter method for property <tt>addressParser</tt>.
+     *
+     * @param addressParser value to be assigned to property addressParser
+     */
+    void setAddressParser(RemotingAddressParser addressParser);
+
+    /**
+     * Setter method for property <tt>monitorStrategy<tt>.
+     *
+     * @param monitorStrategy value to be assigned to property monitorStrategy
+     */
+    void setMonitorStrategy(ConnectionMonitorStrategy monitorStrategy);
+}

--- a/src/main/java/com/alipay/remoting/config/BoltClientOption.java
+++ b/src/main/java/com/alipay/remoting/config/BoltClientOption.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+/**
+ * Supported options in client side.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 18:00
+ */
+public class BoltClientOption<T> extends BoltGenericOption<T> {
+
+    public static final BoltOption<Integer> NETTY_IO_RATIO                = valueOf(
+                                                                              "bolt.tcp.heartbeat.interval",
+                                                                              15 * 1000);
+    public static final BoltOption<Integer> TCP_IDLE_MAXTIMES             = valueOf(
+                                                                              "bolt.tcp.heartbeat.maxtimes",
+                                                                              3);
+
+    public static final BoltOption<Integer> CONN_CREATE_TP_MIN_SIZE       = valueOf(
+                                                                              "bolt.conn.create.tp.min",
+                                                                              3);
+    public static final BoltOption<Integer> CONN_CREATE_TP_MAX_SIZE       = valueOf(
+                                                                              "bolt.conn.create.tp.max",
+                                                                              8);
+    public static final BoltOption<Integer> CONN_CREATE_TP_QUEUE_SIZE     = valueOf(
+                                                                              "bolt.conn.create.tp.queue",
+                                                                              50);
+    public static final BoltOption<Integer> CONN_CREATE_TP_KEEPALIVE_TIME = valueOf(
+                                                                              "bolt.conn.create.tp.keepalive",
+                                                                              60);
+
+    private BoltClientOption(String name, T defaultValue) {
+        super(name, defaultValue);
+    }
+}

--- a/src/main/java/com/alipay/remoting/config/BoltGenericOption.java
+++ b/src/main/java/com/alipay/remoting/config/BoltGenericOption.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+/**
+ * Supported options both in client and server side.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 17:59
+ */
+public class BoltGenericOption<T> extends BoltOption<T> {
+
+    /*------------ NETTY Config Start ------------*/
+    public static final BoltOption<Boolean> TCP_NODELAY                  = valueOf(
+                                                                             "bolt.tcp.nodelay",
+                                                                             true);
+    public static final BoltOption<Boolean> TCP_SO_REUSEADDR             = valueOf(
+                                                                             "bolt.tcp.so.reuseaddr",
+                                                                             true);
+    public static final BoltOption<Boolean> TCP_SO_KEEPALIVE             = valueOf(
+                                                                             "bolt.tcp.so.keepalive",
+                                                                             true);
+
+    public static final BoltOption<Integer> NETTY_IO_RATIO               = valueOf(
+                                                                             "bolt.netty.io.ratio",
+                                                                             70);
+    public static final BoltOption<Boolean> NETTY_BUFFER_POOLED          = valueOf(
+                                                                             "bolt.netty.buffer.pooled",
+                                                                             true);
+
+    public static final BoltOption<Integer> NETTY_BUFFER_HIGH_WATER_MARK = valueOf(
+                                                                             "bolt.netty.buffer.high.watermark",
+                                                                             64 * 1024);
+    public static final BoltOption<Integer> NETTY_BUFFER_LOW_WATER_MARK  = valueOf(
+                                                                             "bolt.netty.buffer.low.watermark",
+                                                                             32 * 1024);
+
+    public static final BoltOption<Boolean> NETTY_EPOLL_SWITCH           = valueOf(
+                                                                             "bolt.netty.epoll.switch",
+                                                                             true);
+
+    public static final BoltOption<Boolean> TCP_IDLE_SWITCH              = valueOf(
+                                                                             "bolt.tcp.heartbeat.switch",
+                                                                             true);
+    /*------------ NETTY Config End ------------*/
+
+    /*------------ Thread Pool Config Start ------------*/
+    public static final BoltOption<Integer> TP_MIN_SIZE                  = valueOf("bolt.tp.min",
+                                                                             20);
+    public static final BoltOption<Integer> TP_MAX_SIZE                  = valueOf("bolt.tp.max",
+                                                                             400);
+    public static final BoltOption<Integer> TP_QUEUE_SIZE                = valueOf("bolt.tp.queue",
+                                                                             600);
+    public static final BoltOption<Integer> TP_KEEPALIVE_TIME            = valueOf(
+                                                                             "bolt.tp.keepalive",
+                                                                             60);
+
+    /*------------ Thread Pool Config End ------------*/
+
+    protected BoltGenericOption(String name, T defaultValue) {
+        super(name, defaultValue);
+    }
+}

--- a/src/main/java/com/alipay/remoting/config/BoltOption.java
+++ b/src/main/java/com/alipay/remoting/config/BoltOption.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+/**
+ * The base implementation class of the configuration item.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 17:25
+ */
+public class BoltOption<T> {
+
+    private final String name;
+    private T            defaultValue;
+
+    protected BoltOption(String name, T defaultValue) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public T defaultValue() {
+        return defaultValue;
+    }
+
+    public static <T> BoltOption<T> valueOf(String name) {
+        return new BoltOption<T>(name, null);
+    }
+
+    public static <T> BoltOption<T> valueOf(String name, T defaultValue) {
+        return new BoltOption<T>(name, defaultValue);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BoltOption<?> that = (BoltOption<?>) o;
+
+        return name != null ? name.equals(that.name) : that.name == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return name != null ? name.hashCode() : 0;
+    }
+}

--- a/src/main/java/com/alipay/remoting/config/BoltOptions.java
+++ b/src/main/java/com/alipay/remoting/config/BoltOptions.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Option carrier.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 17:42
+ */
+public class BoltOptions {
+
+    private ConcurrentHashMap<BoltOption<?>, Object> options = new ConcurrentHashMap<BoltOption<?>, Object>();
+
+    /**
+     * Get the optioned value.
+     * Return default value if option does not exist.
+     *
+     * @param option target option
+     * @return the optioned value of default value if option does not exist.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T option(BoltOption<T> option) {
+        Object value = options.get(option);
+        if (value == null) {
+            value = option.defaultValue();
+        }
+
+        return value == null ? null : (T) value;
+    }
+
+    /**
+     * Set up an new option with specific value.
+     * Use a value of {@code null} to remove a previous set {@link BoltOption}.
+     *
+     * @param option target option
+     * @param value option value, null for remove a previous set {@link BoltOption}.
+     * @return this BoltOptions instance
+     */
+    public <T> BoltOptions option(BoltOption<T> option, T value) {
+        if (value == null) {
+            options.remove(option);
+            return this;
+        }
+
+        options.put(option, value);
+        return this;
+    }
+}

--- a/src/main/java/com/alipay/remoting/config/BoltServerOption.java
+++ b/src/main/java/com/alipay/remoting/config/BoltServerOption.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+/**
+ * Supported options in server side.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 18:00
+ */
+public class BoltServerOption<T> extends BoltGenericOption<T> {
+
+    public static final BoltOption<Integer> TCP_SO_BACKLOG  = valueOf("bolt.tcp.so.backlog", 1024);
+
+    public static final BoltOption<Boolean> NETTY_EPOLL_LT  = valueOf("bolt.netty.epoll.lt", true);
+
+    public static final BoltOption<Integer> TCP_SERVER_IDLE = valueOf(
+                                                                "bolt.tcp.server.idle.interval",
+                                                                90 * 1000);
+
+    private BoltServerOption(String name, T defaultValue) {
+        super(name, defaultValue);
+    }
+}

--- a/src/main/java/com/alipay/remoting/config/Configurable.java
+++ b/src/main/java/com/alipay/remoting/config/Configurable.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting.config;
+
+/**
+ * Config interface.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2018-11-06 14:46
+ */
+public interface Configurable {
+
+    /**
+     * Get the option value.
+     *
+     * @param option target option
+     * @return BoltOption
+     */
+    <T> T option(BoltOption<T> option);
+
+    /**
+     * Allow to specify a {@link BoltOption} which is used for the {@link Configurable} instances once they got
+     * created. Use a value of {@code null} to remove a previous set {@link BoltOption}.
+     *
+     * @param option target option
+     * @param value option value, null to remove the previous option
+     * @return Configurable instance
+     */
+    <T> Configurable option(BoltOption<T> option, T value);
+
+}

--- a/src/main/java/com/alipay/remoting/rpc/RpcClient.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcClient.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.alipay.remoting.AbstractBoltClient;
+import com.alipay.remoting.LifeCycleException;
 import org.slf4j.Logger;
 
 import com.alipay.remoting.Connection;
@@ -28,8 +30,6 @@ import com.alipay.remoting.ConnectionEventListener;
 import com.alipay.remoting.ConnectionEventProcessor;
 import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.ConnectionMonitorStrategy;
-import com.alipay.remoting.ConnectionPool;
-import com.alipay.remoting.ConnectionSelectStrategy;
 import com.alipay.remoting.DefaultConnectionManager;
 import com.alipay.remoting.DefaultConnectionMonitor;
 import com.alipay.remoting.InvokeCallback;
@@ -39,10 +39,7 @@ import com.alipay.remoting.ReconnectManager;
 import com.alipay.remoting.RemotingAddressParser;
 import com.alipay.remoting.ScheduledDisconnectStrategy;
 import com.alipay.remoting.Url;
-import com.alipay.remoting.config.AbstractConfigurableInstance;
-import com.alipay.remoting.config.configs.ConfigType;
 import com.alipay.remoting.config.switches.GlobalSwitch;
-import com.alipay.remoting.connection.ConnectionFactory;
 import com.alipay.remoting.exception.RemotingException;
 import com.alipay.remoting.log.BoltLoggerFactory;
 import com.alipay.remoting.rpc.protocol.UserProcessor;
@@ -54,60 +51,70 @@ import com.alipay.remoting.rpc.protocol.UserProcessorRegisterHelper;
  * @author jiangping
  * @version $Id: RpcClient.java, v 0.1 2015-9-23 PM4:03:28 tao Exp $
  */
-public class RpcClient extends AbstractConfigurableInstance {
+public class RpcClient extends AbstractBoltClient {
 
-    /** logger */
-    private static final Logger                         logger                   = BoltLoggerFactory
-                                                                                     .getLogger("RpcRemoting");
+    private static final Logger                               logger = BoltLoggerFactory
+                                                                         .getLogger("RpcRemoting");
 
-    private ConcurrentHashMap<String, UserProcessor<?>> userProcessors           = new ConcurrentHashMap<String, UserProcessor<?>>();
-    /** connection factory */
-    private ConnectionFactory                           connectionFactory        = new RpcConnectionFactory(
-                                                                                     userProcessors,
-                                                                                     this);
+    private final RpcTaskScanner                              taskScanner;
+    private final ConcurrentHashMap<String, UserProcessor<?>> userProcessors;
+    private final ConnectionEventHandler                      connectionEventHandler;
+    private final ConnectionEventListener                     connectionEventListener;
+    private final DefaultConnectionManager                    connectionManager;
 
-    /** connection event handler */
-    private ConnectionEventHandler                      connectionEventHandler   = new RpcConnectionEventHandler(
-                                                                                     switches());
+    private ReconnectManager                                  reconnectManager;
+    private RemotingAddressParser                             addressParser;
+    private DefaultConnectionMonitor                          connectionMonitor;
+    private ConnectionMonitorStrategy                         monitorStrategy;
 
-    /** reconnect manager */
-    private ReconnectManager                            reconnectManager;
-
-    /** connection event listener */
-    private ConnectionEventListener                     connectionEventListener  = new ConnectionEventListener();
-
-    /** address parser to get custom args */
-    private RemotingAddressParser                       addressParser;
-
-    /** connection select strategy */
-    private ConnectionSelectStrategy                    connectionSelectStrategy = new RandomSelectStrategy(
-                                                                                     switches());
-
-    /** connection manager */
-    private DefaultConnectionManager                    connectionManager        = new DefaultConnectionManager(
-                                                                                     connectionSelectStrategy,
-                                                                                     connectionFactory,
-                                                                                     connectionEventHandler,
-                                                                                     connectionEventListener,
-                                                                                     switches());
-
-    /** rpc remoting */
-    protected RpcRemoting                               rpcRemoting;
-
-    /** task scanner */
-    private RpcTaskScanner                              taskScanner              = new RpcTaskScanner();
-
-    /** connection monitor */
-    private DefaultConnectionMonitor                    connectionMonitor;
-
-    /** connection monitor strategy */
-    private ConnectionMonitorStrategy                   monitorStrategy;
+    // used in RpcClientAdapter (bolt-tr-adapter)
+    protected RpcRemoting                                     rpcRemoting;
 
     public RpcClient() {
-        super(ConfigType.CLIENT_SIDE);
+        this.taskScanner = new RpcTaskScanner();
+        this.userProcessors = new ConcurrentHashMap<String, UserProcessor<?>>();
+        this.connectionEventHandler = new RpcConnectionEventHandler(switches());
+        this.connectionEventListener = new ConnectionEventListener();
+        this.connectionManager = new DefaultConnectionManager(new RandomSelectStrategy(switches()),
+            new RpcConnectionFactory(userProcessors, this), connectionEventHandler,
+            connectionEventListener, switches());
     }
 
+    /**
+     * Please use {@link RpcClient#startup()} instead
+     */
+    @Deprecated
     public void init() {
+        startup();
+    }
+
+    /**
+     * Shutdown.
+     * <p>
+     * Notice:<br>
+     *   <li>Rpc client can not be used any more after shutdown.
+     *   <li>If you need, you should destroy it, and instantiate another one.
+     */
+    @Override
+    public void shutdown() {
+        super.shutdown();
+
+        this.connectionManager.removeAll();
+        logger.warn("Close all connections from client side!");
+        this.taskScanner.shutdown();
+        logger.warn("Rpc client shutdown!");
+        if (reconnectManager != null) {
+            reconnectManager.shutdown();
+        }
+        if (connectionMonitor != null) {
+            connectionMonitor.shutdown();
+        }
+    }
+
+    @Override
+    public void startup() throws LifeCycleException {
+        super.startup();
+
         if (this.addressParser == null) {
             this.addressParser = new RpcAddressParser();
         }
@@ -116,7 +123,7 @@ public class RpcClient extends AbstractConfigurableInstance {
         this.rpcRemoting = new RpcClientRemoting(new RpcCommandFactory(), this.addressParser,
             this.connectionManager);
         this.taskScanner.add(this.connectionManager);
-        this.taskScanner.start();
+        this.taskScanner.startup();
 
         if (switches().isOn(GlobalSwitch.CONN_MONITOR_SWITCH)) {
             if (monitorStrategy == null) {
@@ -126,7 +133,7 @@ public class RpcClient extends AbstractConfigurableInstance {
                 connectionMonitor = new DefaultConnectionMonitor(monitorStrategy,
                     this.connectionManager);
             }
-            connectionMonitor.start();
+            connectionMonitor.startup();
             logger.warn("Switch on connection monitor");
         }
         if (switches().isOn(GlobalSwitch.CONN_RECONNECT_SWITCH)) {
@@ -138,218 +145,66 @@ public class RpcClient extends AbstractConfigurableInstance {
         }
     }
 
-    /**
-     * Shutdown.
-     * <p>
-     * Notice:<br>
-     *   <li>Rpc client can not be used any more after shutdown.
-     *   <li>If you need, you should destroy it, and instantiate another one.
-     */
-    public void shutdown() {
-        this.connectionManager.removeAll();
-        logger.warn("Close all connections from client side!");
-        this.taskScanner.shutdown();
-        logger.warn("Rpc client shutdown!");
-        if (reconnectManager != null) {
-            reconnectManager.shutdown();
-        }
-        if (connectionMonitor != null) {
-            connectionMonitor.destroy();
-        }
+    @Override
+    public void oneway(final String address, final Object request) throws RemotingException,
+                                                                  InterruptedException {
+        this.rpcRemoting.oneway(address, request, null);
     }
 
-    /**
-     * One way invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
-     *   </ol>
-     * 
-     * @param addr
-     * @param request
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public void oneway(final String addr, final Object request) throws RemotingException,
-                                                               InterruptedException {
-        this.rpcRemoting.oneway(addr, request, null);
+    @Override
+    public void oneway(final String address, final Object request, final InvokeContext invokeContext)
+                                                                                                     throws RemotingException,
+                                                                                                     InterruptedException {
+        this.rpcRemoting.oneway(address, request, invokeContext);
     }
 
-    /**
-     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Connection, Object)}
-     *
-     * @param addr
-     * @param request
-     * @param invokeContext
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public void oneway(final String addr, final Object request, final InvokeContext invokeContext)
-                                                                                                  throws RemotingException,
-                                                                                                  InterruptedException {
-        this.rpcRemoting.oneway(addr, request, invokeContext);
-    }
-
-    /**
-     * One way invocation using a parsed {@link Url} <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
-     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
-     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
-     *   </ol>
-     * 
-     * @param url
-     * @param request
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public void oneway(final Url url, final Object request) throws RemotingException,
                                                            InterruptedException {
         this.rpcRemoting.oneway(url, request, null);
     }
 
-    /**
-     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Url, Object)}
-     *
-     * @param url
-     * @param request
-     * @param invokeContext
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public void oneway(final Url url, final Object request, final InvokeContext invokeContext)
                                                                                               throws RemotingException,
                                                                                               InterruptedException {
         this.rpcRemoting.oneway(url, request, invokeContext);
     }
 
-    /**
-     * One way invocation using a {@link Connection} <br>
-     * <p>
-     * Notice:<br>
-     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
-     * 
-     * @param conn
-     * @param request
-     * @throws RemotingException
-     */
+    @Override
     public void oneway(final Connection conn, final Object request) throws RemotingException {
         this.rpcRemoting.oneway(conn, request, null);
     }
 
-    /**
-     * Oneway invocation with a {@link InvokeContext}, common api notice please see {@link #oneway(Connection, Object)}
-     *
-     * @param conn
-     * @param request
-     * @param invokeContext
-     * @throws RemotingException
-     */
+    @Override
     public void oneway(final Connection conn, final Object request,
                        final InvokeContext invokeContext) throws RemotingException {
         this.rpcRemoting.oneway(conn, request, invokeContext);
     }
 
-    /**
-     * Synchronous invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
-     *   </ol>
-     * 
-     * @param addr
-     * @param request
-     * @param timeoutMillis
-     * @return Object
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public Object invokeSync(final String addr, final Object request, final int timeoutMillis)
-                                                                                              throws RemotingException,
-                                                                                              InterruptedException {
-        return this.rpcRemoting.invokeSync(addr, request, null, timeoutMillis);
+    @Override
+    public Object invokeSync(final String address, final Object request, final int timeoutMillis)
+                                                                                                 throws RemotingException,
+                                                                                                 InterruptedException {
+        return this.rpcRemoting.invokeSync(address, request, null, timeoutMillis);
     }
 
-    /**
-     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(String, Object, int)}
-     *
-     * @param addr
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public Object invokeSync(final String addr, final Object request,
+    @Override
+    public Object invokeSync(final String address, final Object request,
                              final InvokeContext invokeContext, final int timeoutMillis)
                                                                                         throws RemotingException,
                                                                                         InterruptedException {
-        return this.rpcRemoting.invokeSync(addr, request, invokeContext, timeoutMillis);
+        return this.rpcRemoting.invokeSync(address, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Synchronous invocation using a parsed {@link Url} <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
-     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
-     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
-     *   </ol>
-     * 
-     * @param url
-     * @param request
-     * @param timeoutMillis
-     * @return Object
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public Object invokeSync(final Url url, final Object request, final int timeoutMillis)
                                                                                           throws RemotingException,
                                                                                           InterruptedException {
         return this.invokeSync(url, request, null, timeoutMillis);
     }
 
-    /**
-     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(Url, Object, int)}
-     *
-     * @param url
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public Object invokeSync(final Url url, final Object request,
                              final InvokeContext invokeContext, final int timeoutMillis)
                                                                                         throws RemotingException,
@@ -357,36 +212,14 @@ public class RpcClient extends AbstractConfigurableInstance {
         return this.rpcRemoting.invokeSync(url, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Synchronous invocation using a {@link Connection} <br>
-     * <p>
-     * Notice:<br>
-     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
-     * 
-     * @param conn
-     * @param request
-     * @param timeoutMillis
-     * @return Object
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public Object invokeSync(final Connection conn, final Object request, final int timeoutMillis)
                                                                                                   throws RemotingException,
                                                                                                   InterruptedException {
         return this.rpcRemoting.invokeSync(conn, request, null, timeoutMillis);
     }
 
-    /**
-     * Synchronous invocation with a {@link InvokeContext}, common api notice please see {@link #invokeSync(Connection, Object, int)}
-     *
-     * @param conn
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return Object
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public Object invokeSync(final Connection conn, final Object request,
                              final InvokeContext invokeContext, final int timeoutMillis)
                                                                                         throws RemotingException,
@@ -394,93 +227,29 @@ public class RpcClient extends AbstractConfigurableInstance {
         return this.rpcRemoting.invokeSync(conn, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Future invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
-     * You can get result use the returned {@link RpcResponseFuture}.
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
-     *   </ol>
-     * 
-     * @param addr
-     * @param request
-     * @param timeoutMillis
-     * @return RpcResponseFuture
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public RpcResponseFuture invokeWithFuture(final String addr, final Object request,
+    @Override
+    public RpcResponseFuture invokeWithFuture(final String address, final Object request,
                                               final int timeoutMillis) throws RemotingException,
                                                                       InterruptedException {
-        return this.rpcRemoting.invokeWithFuture(addr, request, null, timeoutMillis);
+        return this.rpcRemoting.invokeWithFuture(address, request, null, timeoutMillis);
     }
 
-    /**
-     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(String, Object, int)}
-     *
-     * @param addr
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return RpcResponseFuture
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public RpcResponseFuture invokeWithFuture(final String addr, final Object request,
+    @Override
+    public RpcResponseFuture invokeWithFuture(final String address, final Object request,
                                               final InvokeContext invokeContext,
                                               final int timeoutMillis) throws RemotingException,
                                                                       InterruptedException {
-        return this.rpcRemoting.invokeWithFuture(addr, request, invokeContext, timeoutMillis);
+        return this.rpcRemoting.invokeWithFuture(address, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Future invocation using a parsed {@link Url} <br>
-     * You can get result use the returned {@link RpcResponseFuture}.
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
-     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
-     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
-     *   </ol>
-     * 
-     * @param url
-     * @param request
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public RpcResponseFuture invokeWithFuture(final Url url, final Object request,
                                               final int timeoutMillis) throws RemotingException,
                                                                       InterruptedException {
         return this.rpcRemoting.invokeWithFuture(url, request, null, timeoutMillis);
     }
 
-    /**
-     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(Url, Object, int)}
-     *
-     * @param url
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public RpcResponseFuture invokeWithFuture(final Url url, final Object request,
                                               final InvokeContext invokeContext,
                                               final int timeoutMillis) throws RemotingException,
@@ -488,113 +257,38 @@ public class RpcClient extends AbstractConfigurableInstance {
         return this.rpcRemoting.invokeWithFuture(url, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Future invocation using a {@link Connection} <br>
-     * You can get result use the returned {@link RpcResponseFuture}.
-     * <p>
-     * Notice:<br>
-     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
-     * 
-     * @param conn
-     * @param request
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     */
+    @Override
     public RpcResponseFuture invokeWithFuture(final Connection conn, final Object request,
                                               int timeoutMillis) throws RemotingException {
         return this.rpcRemoting.invokeWithFuture(conn, request, null, timeoutMillis);
     }
 
-    /**
-     * Future invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithFuture(Connection, Object, int)}
-     *
-     * @param conn
-     * @param request
-     * @param invokeContext
-     * @param timeoutMillis
-     * @return
-     * @throws RemotingException
-     */
+    @Override
     public RpcResponseFuture invokeWithFuture(final Connection conn, final Object request,
                                               final InvokeContext invokeContext, int timeoutMillis)
                                                                                                    throws RemotingException {
         return this.rpcRemoting.invokeWithFuture(conn, request, invokeContext, timeoutMillis);
     }
 
-    /**
-     * Callback invocation using a string address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
-     * You can specify an implementation of {@link InvokeCallback} to get the result.
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the string address to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(String addr)} to close it if you want.
-     *   </ol>
-     * 
-     * @param addr
-     * @param request
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public void invokeWithCallback(final String addr, final Object request,
+    @Override
+    public void invokeWithCallback(final String address, final Object request,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
                                                                                                 throws RemotingException,
                                                                                                 InterruptedException {
-        this.rpcRemoting.invokeWithCallback(addr, request, null, invokeCallback, timeoutMillis);
+        this.rpcRemoting.invokeWithCallback(address, request, null, invokeCallback, timeoutMillis);
     }
 
-    /**
-     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(String, Object, InvokeCallback, int)}
-     *
-     * @param addr
-     * @param request
-     * @param invokeContext
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
-    public void invokeWithCallback(final String addr, final Object request,
+    @Override
+    public void invokeWithCallback(final String address, final Object request,
                                    final InvokeContext invokeContext,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
                                                                                                 throws RemotingException,
                                                                                                 InterruptedException {
-        this.rpcRemoting.invokeWithCallback(addr, request, invokeContext, invokeCallback,
+        this.rpcRemoting.invokeWithCallback(address, request, invokeContext, invokeCallback,
             timeoutMillis);
     }
 
-    /**
-     * Callback invocation using a parsed {@link Url} <br>
-     * You can specify an implementation of {@link InvokeCallback} to get the result.
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li><b>DO NOT modify the request object concurrently when this method is called.</b></li>
-     *   <li>When do invocation, use the parsed {@link Url} to find a available connection, if none then create one.</li> 
-     *      <ul>
-     *        <li>You can use {@link Url#setConnectTimeout} to specify connection timeout, time unit is milliseconds.
-     *        <li>You can use {@link Url#setConnNum} to specify connection number for each ip and port.
-     *        <li>You can use {@link Url#setConnWarmup} to specify whether need warmup all connections for the first time you call this method.
-     *      </ul>
-     *   <li>You should use {@link #closeConnection(Url url)} to close it if you want.
-     *   </ol>
-     * 
-     * @param url
-     * @param request
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public void invokeWithCallback(final Url url, final Object request,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
                                                                                                 throws RemotingException,
@@ -602,17 +296,7 @@ public class RpcClient extends AbstractConfigurableInstance {
         this.rpcRemoting.invokeWithCallback(url, request, null, invokeCallback, timeoutMillis);
     }
 
-    /**
-     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(Url, Object, InvokeCallback, int)}
-     *
-     * @param url
-     * @param request
-     * @param invokeContext
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     * @throws InterruptedException
-     */
+    @Override
     public void invokeWithCallback(final Url url, final Object request,
                                    final InvokeContext invokeContext,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
@@ -622,35 +306,14 @@ public class RpcClient extends AbstractConfigurableInstance {
             timeoutMillis);
     }
 
-    /**
-     * Callback invocation using a {@link Connection} <br>
-     * You can specify an implementation of {@link InvokeCallback} to get the result.
-     * <p>
-     * Notice:<br>
-     *   <b>DO NOT modify the request object concurrently when this method is called.</b>
-     * 
-     * @param conn
-     * @param request
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     */
+    @Override
     public void invokeWithCallback(final Connection conn, final Object request,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
                                                                                                 throws RemotingException {
         this.rpcRemoting.invokeWithCallback(conn, request, null, invokeCallback, timeoutMillis);
     }
 
-    /**
-     * Callback invocation with a {@link InvokeContext}, common api notice please see {@link #invokeWithCallback(Connection, Object, InvokeCallback, int)}
-     *
-     * @param conn
-     * @param request
-     * @param invokeContext
-     * @param invokeCallback
-     * @param timeoutMillis
-     * @throws RemotingException
-     */
+    @Override
     public void invokeWithCallback(final Connection conn, final Object request,
                                    final InvokeContext invokeContext,
                                    final InvokeCallback invokeCallback, final int timeoutMillis)
@@ -659,142 +322,58 @@ public class RpcClient extends AbstractConfigurableInstance {
             timeoutMillis);
     }
 
-    /**
-     * Add processor to process connection event.
-     * 
-     * @param type
-     * @param processor
-     */
+    @Override
     public void addConnectionEventProcessor(ConnectionEventType type,
                                             ConnectionEventProcessor processor) {
         this.connectionEventListener.addConnectionEventProcessor(type, processor);
     }
 
-    /**
-     * Use UserProcessorRegisterHelper{@link UserProcessorRegisterHelper} to help register user processor for client side.
-     *
-     * @param processor
-     * @throws RemotingException 
-     */
-
+    @Override
     public void registerUserProcessor(UserProcessor<?> processor) {
         UserProcessorRegisterHelper.registerUserProcessor(processor, this.userProcessors);
     }
 
-    /**
-     * Create a stand alone connection using ip and port. <br>
-     * <p>
-     * Notice:<br>
-     *   <li>Each time you call this method, will create a new connection.
-     *   <li>Bolt will not control this connection.
-     *   <li>You should use {@link #closeStandaloneConnection} to close it.
-     * 
-     * @param ip
-     * @param port
-     * @param connectTimeout
-     * @return
-     * @throws RemotingException
-     */
+    @Override
     public Connection createStandaloneConnection(String ip, int port, int connectTimeout)
                                                                                          throws RemotingException {
         return this.connectionManager.create(ip, port, connectTimeout);
     }
 
-    /**
-     * Create a stand alone connection using address, address format example - 127.0.0.1:12200 <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li>Each time you can this method, will create a new connection.
-     *   <li>Bolt will not control this connection.
-     *   <li>You should use {@link #closeStandaloneConnection} to close it.
-     *   </ol>
-     * 
-     * @param addr
-     * @param connectTimeout
-     * @return
-     * @throws RemotingException
-     */
-    public Connection createStandaloneConnection(String addr, int connectTimeout)
-                                                                                 throws RemotingException {
-        return this.connectionManager.create(addr, connectTimeout);
+    @Override
+    public Connection createStandaloneConnection(String address, int connectTimeout)
+                                                                                    throws RemotingException {
+        return this.connectionManager.create(address, connectTimeout);
     }
 
-    /**
-     * Close a standalone connection
-     * 
-     * @param conn
-     */
+    @Override
     public void closeStandaloneConnection(Connection conn) {
         if (null != conn) {
             conn.close();
         }
     }
 
-    /**
-     * Get a connection using address, address format example - 127.0.0.1:12200?key1=value1&key2=value2 <br>
-     * <p>
-     * Notice:<br>
-     *   <ol>
-     *   <li>Get a connection, if none then create.</li> 
-     *      <ul>
-     *        <li>You can use {@link RpcConfigs#CONNECT_TIMEOUT_KEY} to specify connection timeout, time unit is milliseconds, e.g [127.0.0.1:12200?_CONNECTTIMEOUT=3000]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_NUM_KEY} to specify connection number for each ip and port, e.g [127.0.0.1:12200?_CONNECTIONNUM=30]
-     *        <li>You can use {@link RpcConfigs#CONNECTION_WARMUP_KEY} to specify whether need warmup all connections for the first time you call this method, e.g [127.0.0.1:12200?_CONNECTIONWARMUP=false]
-     *      </ul>
-     *   <li>Bolt will control this connection in {@link ConnectionPool}
-     *   <li>You should use {@link #closeConnection(String addr)} to close it.
-     *   </ol>
-     * @param addr
-     * @param connectTimeout this is prior to url args {@link RpcConfigs#CONNECT_TIMEOUT_KEY}
-     * @return
-     * @throws RemotingException
-     */
-    public Connection getConnection(String addr, int connectTimeout) throws RemotingException,
-                                                                    InterruptedException {
-        Url url = this.addressParser.parse(addr);
+    @Override
+    public Connection getConnection(String address, int connectTimeout) throws RemotingException,
+                                                                       InterruptedException {
+        Url url = this.addressParser.parse(address);
         return this.getConnection(url, connectTimeout);
     }
 
-    /**
-     * Get a connection using a {@link Url}.<br>
-     * <p> 
-     * Notice: 
-     *   <ol>
-     *   <li>Get a connection, if none then create.
-     *   <li>Bolt will control this connection in {@link com.alipay.remoting.ConnectionPool}
-     *   <li>You should use {@link #closeConnection(Url url)} to close it.
-     *   </ol>
-     * 
-     * @param url
-     * @param connectTimeout this is prior to url args {@link RpcConfigs#CONNECT_TIMEOUT_KEY}
-     * @return
-     * @throws RemotingException
-     */
+    @Override
     public Connection getConnection(Url url, int connectTimeout) throws RemotingException,
                                                                 InterruptedException {
         url.setConnectTimeout(connectTimeout);
         return this.connectionManager.getAndCreateIfAbsent(url);
     }
 
-    /**
-     * get all connections managed by rpc client
-     *
-     * @return map key is ip+port, value is a list of connections of this key.
-     */
+    @Override
     public Map<String, List<Connection>> getAllManagedConnections() {
         return this.connectionManager.getAll();
     }
 
-    /**
-     * check connection, the address format example - 127.0.0.1:12200?key1=value1&key2=value2
-     *
-     * @param addr
-     * @throws RemotingException
-     * @return true if and only if there is a connection, and the connection is active and writable;else return false
-     */
-    public boolean checkConnection(String addr) {
-        Url url = this.addressParser.parse(addr);
+    @Override
+    public boolean checkConnection(String address) {
+        Url url = this.addressParser.parse(address);
         Connection conn = this.connectionManager.get(url.getUniqueKey());
         try {
             this.connectionManager.check(conn);
@@ -805,158 +384,89 @@ public class RpcClient extends AbstractConfigurableInstance {
         return true;
     }
 
-    /**
-     * Close all connections of a address
-     * 
-     * @param addr
-     */
-    public void closeConnection(String addr) {
-        Url url = this.addressParser.parse(addr);
+    @Override
+    public void closeConnection(String address) {
+        Url url = this.addressParser.parse(address);
         this.connectionManager.remove(url.getUniqueKey());
     }
 
-    /**
-     * Close all connections of a {@link Url}
-     * 
-     * @param url
-     */
+    @Override
     public void closeConnection(Url url) {
         this.connectionManager.remove(url.getUniqueKey());
     }
 
-    /**
-     * Enable heart beat for a certain connection. 
-     * If this address not connected, then do nothing.
-     * <p>
-     * Notice: this method takes no effect on a stand alone connection.
-     * 
-     * @param addr
-     */
-    public void enableConnHeartbeat(String addr) {
-        Url url = this.addressParser.parse(addr);
+    @Override
+    public void enableConnHeartbeat(String address) {
+        Url url = this.addressParser.parse(address);
         this.enableConnHeartbeat(url);
     }
 
-    /**
-     * Enable heart beat for a certain connection. 
-     * If this {@link Url} not connected, then do nothing.
-     * <p>
-     * Notice: this method takes no effect on a stand alone connection.
-     * 
-     * @param url
-     */
+    @Override
     public void enableConnHeartbeat(Url url) {
         if (null != url) {
             this.connectionManager.enableHeartbeat(this.connectionManager.get(url.getUniqueKey()));
         }
     }
 
-    /**
-     * Disable heart beat for a certain connection. 
-     * If this addr not connected, then do nothing.
-     * <p>
-     * Notice: this method takes no effect on a stand alone connection.
-     * 
-     * @param addr
-     */
-    public void disableConnHeartbeat(String addr) {
-        Url url = this.addressParser.parse(addr);
+    @Override
+    public void disableConnHeartbeat(String address) {
+        Url url = this.addressParser.parse(address);
         this.disableConnHeartbeat(url);
     }
 
-    /**
-     * Disable heart beat for a certain connection. 
-     * If this {@link Url} not connected, then do nothing.
-     * <p>
-     * Notice: this method takes no effect on a stand alone connection.
-     * 
-     * @param url
-     */
+    @Override
     public void disableConnHeartbeat(Url url) {
         if (null != url) {
             this.connectionManager.disableHeartbeat(this.connectionManager.get(url.getUniqueKey()));
         }
     }
 
-    /**
-     * enable connection reconnect switch on
-     * <p>
-     * Notice: This api should be called before {@link RpcClient#init()}
-     */
+    @Override
     public void enableReconnectSwitch() {
         this.switches().turnOn(GlobalSwitch.CONN_RECONNECT_SWITCH);
     }
 
-    /**
-     * disable connection reconnect switch off
-     * <p>
-     * Notice: This api should be called before {@link RpcClient#init()}
-     */
+    @Override
     public void disableReconnectSwith() {
         this.switches().turnOff(GlobalSwitch.CONN_RECONNECT_SWITCH);
     }
 
-    /**
-     * is reconnect switch on
-     * @return
-     */
+    @Override
     public boolean isReconnectSwitchOn() {
         return this.switches().isOn(GlobalSwitch.CONN_RECONNECT_SWITCH);
     }
 
-    /**
-     * enable connection monitor switch on
-     */
+    @Override
     public void enableConnectionMonitorSwitch() {
         this.switches().turnOn(GlobalSwitch.CONN_MONITOR_SWITCH);
     }
 
-    /**
-     * disable connection monitor switch off
-     * <p>
-     * Notice: This api should be called before {@link RpcClient#init()}
-     */
+    @Override
     public void disableConnectionMonitorSwitch() {
         this.switches().turnOff(GlobalSwitch.CONN_MONITOR_SWITCH);
     }
 
-    /**
-     * is connection monitor switch on
-     * @return
-     */
+    @Override
     public boolean isConnectionMonitorSwitchOn() {
         return this.switches().isOn(GlobalSwitch.CONN_MONITOR_SWITCH);
     }
 
-    // ~~~ getter and setter
-
-    protected DefaultConnectionManager getConnectionManager() {
+    @Override
+    public DefaultConnectionManager getConnectionManager() {
         return this.connectionManager;
     }
 
-    /**
-     * Getter method for property <tt>addressParser</tt>.
-     * 
-     * @return property value of addressParser
-     */
+    @Override
     public RemotingAddressParser getAddressParser() {
         return this.addressParser;
     }
 
-    /**
-     * Setter method for property <tt>addressParser</tt>.
-     * 
-     * @param addressParser value to be assigned to property addressParser
-     */
+    @Override
     public void setAddressParser(RemotingAddressParser addressParser) {
         this.addressParser = addressParser;
     }
 
-    /**
-     * Setter method for property <tt>monitorStrategy<tt>.
-     *
-     * @param monitorStrategy value to be assigned to property monitorStrategy
-     */
+    @Override
     public void setMonitorStrategy(ConnectionMonitorStrategy monitorStrategy) {
         this.monitorStrategy = monitorStrategy;
     }


### PR DESCRIPTION
1. 重构RpcClient，统一使用LifeCycle管理组件的生命周期
2. 增加了Option模块（只是添加模块代码，暂未使用）