### PR TITLE
refactory ConnectionManager to support start/shutdown operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/alipay/sofa-bolt.svg?branch=master)](https://travis-ci.org/alipay/sofa-bolt)
 [![Coverage Status](https://codecov.io/gh/alipay/sofa-bolt/branch/master/graph/badge.svg)](https://codecov.io/gh/alipay/sofa-bolt)
 ![license](https://img.shields.io/badge/license-Apache--2.0-green.svg)
-![version](https://img.shields.io/badge/bolt-1.6.0-blue.svg)
+![version](https://img.shields.io/maven-central/v/com.alipay.sofa/bolt.svg?label=bolt)
 
 # 1. 介绍
 SOFABolt 是蚂蚁金融服务集团开发的一套基于 Netty 实现的网络通信框架。

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <properties>
         <cobertura.maven.plugin>2.6</cobertura.maven.plugin>
         <coveralls.maven.plugin>3.2.1</coveralls.maven.plugin>
-        <hessian.version>3.3.2</hessian.version>
+        <hessian.version>3.3.6</hessian.version>
         <java.version>1.6</java.version>
         <license.maven.plugin>3.0</license.maven.plugin>
         <maven.assembly.plugin>3.0.0</maven.assembly.plugin>

--- a/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
+++ b/src/main/java/com/alipay/remoting/AbstractRemotingProcessor.java
@@ -52,7 +52,7 @@ public abstract class AbstractRemotingProcessor<T extends RemotingCommand> imple
 
     /**
      * Constructor.
-     * @param executor
+     * @param executor ExecutorService
      */
     public AbstractRemotingProcessor(ExecutorService executor) {
         this.executor = executor;
@@ -60,7 +60,9 @@ public abstract class AbstractRemotingProcessor<T extends RemotingCommand> imple
 
     /**
      * Constructor.
-     * @param executor
+     *
+     * @param commandFactory CommandFactory
+     * @param executor ExecutorService
      */
     public AbstractRemotingProcessor(CommandFactory commandFactory, ExecutorService executor) {
         this.commandFactory = commandFactory;
@@ -70,19 +72,17 @@ public abstract class AbstractRemotingProcessor<T extends RemotingCommand> imple
     /**
      * Do the process.
      * 
-     * @param ctx
-     * @param msg
-     * @throws Exception
+     * @param ctx RemotingContext
+     * @param msg T
      */
     public abstract void doProcess(RemotingContext ctx, T msg) throws Exception;
 
     /**
      * Process the remoting command with its own executor or with the defaultExecutor if its own if null.
      * 
-     * @param ctx
-     * @param msg
-     * @param defaultExecutor
-     * @throws Exception
+     * @param ctx RemotingContext
+     * @param msg T
+     * @param defaultExecutor ExecutorService, default executor
      */
     @Override
     public void process(RemotingContext ctx, T msg, ExecutorService defaultExecutor)
@@ -139,9 +139,6 @@ public abstract class AbstractRemotingProcessor<T extends RemotingCommand> imple
             this.msg = msg;
         }
 
-        /** 
-         * @see java.lang.Runnable#run()
-         */
         @Override
         public void run() {
             try {

--- a/src/main/java/com/alipay/remoting/BizContext.java
+++ b/src/main/java/com/alipay/remoting/BizContext.java
@@ -26,28 +26,28 @@ public interface BizContext {
     /**
      * get remote address
      * 
-     * @return
+     * @return remote address
      */
     String getRemoteAddress();
 
     /**
      * get remote host ip
      * 
-     * @return
+     * @return remote host
      */
     String getRemoteHost();
 
     /**
      * get remote port
      * 
-     * @return
+     * @return remote port
      */
     int getRemotePort();
 
     /**
      * get the connection of this request
      *
-     * @return
+     * @return connection
      */
     Connection getConnection();
 
@@ -61,36 +61,34 @@ public interface BizContext {
     /**
      * get the timeout value from rpc client.
      *
-     * @return
+     * @return client timeout
      */
     int getClientTimeout();
 
     /**
      * get the arrive time stamp
      *
-     * @return
+     * @return the arrive time stamp
      */
     long getArriveTimestamp();
 
     /**
      * put a key and value
-     * 
-     * @return
      */
     void put(String key, String value);
 
     /**
      * get value
      * 
-     * @param key
-     * @return
+     * @param key target key
+     * @return value
      */
     String get(String key);
 
     /**
      * get invoke context.
      *
-     * @return
+     * @return InvokeContext
      */
     InvokeContext getInvokeContext();
 }

--- a/src/main/java/com/alipay/remoting/ClientConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/ClientConnectionManager.java
@@ -17,16 +17,10 @@
 package com.alipay.remoting;
 
 /**
- * Async context for biz.
- * 
- * @author xiaomin.cxm
- * @version $Id: AsyncContext.java, v 0.1 May 19, 2016 2:19:05 PM xiaomin.cxm Exp $
+ * Connection manager in client side.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2019-03-07 12:12
  */
-public interface AsyncContext {
-    /**
-     * send response back
-     * 
-     * @param responseObject response object
-     */
-    void sendResponse(Object responseObject);
+public interface ClientConnectionManager extends ConnectionManager, LifeCycle {
+
 }

--- a/src/main/java/com/alipay/remoting/Connection.java
+++ b/src/main/java/com/alipay/remoting/Connection.java
@@ -95,7 +95,7 @@ public class Connection {
     /**
      * Constructor
      *
-     * @param channel
+     * @param channel associated channel
      */
     public Connection(Channel channel) {
         this.channel = channel;
@@ -105,8 +105,8 @@ public class Connection {
     /**
      * Constructor
      *
-     * @param channel
-     * @param url
+     * @param channel associated channel
+     * @param url associated url
      */
     public Connection(Channel channel, Url url) {
         this(channel);
@@ -117,9 +117,9 @@ public class Connection {
     /**
      * Constructor
      *
-     * @param channel
-     * @param protocolCode
-     * @param url
+     * @param channel associated channel
+     * @param protocolCode ProtocolCode
+     * @param url associated url
      */
     public Connection(Channel channel, ProtocolCode protocolCode, Url url) {
         this(channel, url);
@@ -128,11 +128,11 @@ public class Connection {
     }
 
     /**
-     * Constructor
      *
-     * @param channel
-     * @param protocolCode
-     * @param url
+     * @param channel associated channel
+     * @param protocolCode ProtocolCode
+     * @param version protocol version
+     * @param url associated url
      */
     public Connection(Channel channel, ProtocolCode protocolCode, byte version, Url url) {
         this(channel, url);
@@ -145,7 +145,7 @@ public class Connection {
      * Initialization.
      */
     private void init() {
-        this.channel.attr(HEARTBEAT_COUNT).set(new Integer(0));
+        this.channel.attr(HEARTBEAT_COUNT).set(0);
         this.channel.attr(PROTOCOL).set(this.protocolCode);
         this.channel.attr(VERSION).set(this.version);
         this.channel.attr(HEARTBEAT_SWITCH).set(true);
@@ -154,7 +154,7 @@ public class Connection {
     /**
      * to check whether the connection is fine to use
      *
-     * @return
+     * @return true if connection is fine
      */
     public boolean isFine() {
         return this.channel != null && this.channel.isActive();
@@ -177,7 +177,7 @@ public class Connection {
     /**
      * to check whether the reference count is 0
      *
-     * @return
+     * @return true if the reference count is 0
      */
     public boolean noRef() {
         return this.referenceCount.get() == NO_REFERENCE;
@@ -186,7 +186,7 @@ public class Connection {
     /**
      * Get the address of the remote peer.
      *
-     * @return
+     * @return remote address
      */
     public InetSocketAddress getRemoteAddress() {
         return (InetSocketAddress) this.channel.remoteAddress();
@@ -195,7 +195,7 @@ public class Connection {
     /**
      * Get the remote IP.
      *
-     * @return
+     * @return remote IP
      */
     public String getRemoteIP() {
         return RemotingUtil.parseRemoteIP(this.channel);
@@ -204,7 +204,7 @@ public class Connection {
     /**
      * Get the remote port.
      *
-     * @return
+     * @return remote port
      */
     public int getRemotePort() {
         return RemotingUtil.parseRemotePort(this.channel);
@@ -213,7 +213,7 @@ public class Connection {
     /**
      * Get the address of the local peer.
      *
-     * @return
+     * @return local address
      */
     public InetSocketAddress getLocalAddress() {
         return (InetSocketAddress) this.channel.localAddress();
@@ -222,7 +222,7 @@ public class Connection {
     /**
      * Get the local IP.
      *
-     * @return
+     * @return local IP
      */
     public String getLocalIP() {
         return RemotingUtil.parseLocalIP(this.channel);
@@ -231,7 +231,7 @@ public class Connection {
     /**
      * Get the local port.
      *
-     * @return
+     * @return local port
      */
     public int getLocalPort() {
         return RemotingUtil.parseLocalPort(this.channel);
@@ -240,7 +240,7 @@ public class Connection {
     /**
      * Get the netty channel of the connection.
      *
-     * @return
+     * @return Channel
      */
     public Channel getChannel() {
         return this.channel;
@@ -249,8 +249,8 @@ public class Connection {
     /**
      * Get the InvokeFuture with invokeId of id.
      *
-     * @param id
-     * @return
+     * @param id invoke id
+     * @return InvokeFuture
      */
     public InvokeFuture getInvokeFuture(int id) {
         return this.invokeFutureMap.get(id);
@@ -259,8 +259,8 @@ public class Connection {
     /**
      * Add an InvokeFuture
      *
-     * @param future
-     * @return
+     * @param future InvokeFuture
+     * @return previous InvokeFuture with same invoke id
      */
     public InvokeFuture addInvokeFuture(InvokeFuture future) {
         return this.invokeFutureMap.putIfAbsent(future.invokeId(), future);
@@ -269,8 +269,8 @@ public class Connection {
     /**
      * Remove InvokeFuture who's invokeId is id
      *
-     * @param id
-     * @return
+     * @param id invoke id
+     * @return associated InvokerFuture with the target id
      */
     public InvokeFuture removeInvokeFuture(int id) {
         return this.invokeFutureMap.remove(id);
@@ -333,7 +333,7 @@ public class Connection {
     /**
      * add a pool key to list
      *
-     * @param poolKey
+     * @param poolKey connection pool key
      */
     public void addPoolKey(String poolKey) {
         poolKeys.add(poolKey);
@@ -349,7 +349,7 @@ public class Connection {
     /**
      * remove pool key
      *
-     * @param poolKey
+     * @param poolKey connection pool key
      */
     public void removePoolKey(String poolKey) {
         poolKeys.remove(poolKey);
@@ -367,8 +367,8 @@ public class Connection {
     /**
      * add Id to group Mapping
      *
-     * @param id
-     * @param poolKey
+     * @param id invoke id
+     * @param poolKey connection pool key
      */
     public void addIdPoolKeyMapping(Integer id, String poolKey) {
         this.id2PoolKey.put(id, poolKey);
@@ -377,8 +377,8 @@ public class Connection {
     /**
      * remove id to group Mapping
      *
-     * @param id
-     * @return
+     * @param id connection pool key
+     * @return connection pool key
      */
     public String removeIdPoolKeyMapping(Integer id) {
         return this.id2PoolKey.remove(id);
@@ -387,8 +387,8 @@ public class Connection {
     /**
      * Set attribute key=value.
      *
-     * @param key
-     * @param value
+     * @param key attribute key
+     * @param value attribute value
      */
     public void setAttribute(String key, Object value) {
         attributes.put(key, value);
@@ -397,9 +397,9 @@ public class Connection {
     /**
      * set attribute if key absent.
      *
-     * @param key
-     * @param value
-     * @return
+     * @param key attribute key
+     * @param value attribute value
+     * @return previous value
      */
     public Object setAttributeIfAbsent(String key, Object value) {
         return attributes.putIfAbsent(key, value);
@@ -408,7 +408,7 @@ public class Connection {
     /**
      * Remove attribute.
      *
-     * @param key
+     * @param key attribute key
      */
     public void removeAttribute(String key) {
         attributes.remove(key);
@@ -417,8 +417,8 @@ public class Connection {
     /**
      * Get attribute.
      *
-     * @param key
-     * @return
+     * @param key attribute key
+     * @return attribute value
      */
     public Object getAttribute(String key) {
         return attributes.get(key);

--- a/src/main/java/com/alipay/remoting/ConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/ConnectionManager.java
@@ -27,10 +27,12 @@ import com.alipay.remoting.exception.RemotingException;
  * @author xiaomin.cxm
  * @version $Id: ConnectionManager.java, v 0.1 Mar 7, 2016 2:42:46 PM xiaomin.cxm Exp $
  */
-public interface ConnectionManager extends Scannable {
+public interface ConnectionManager extends Scannable, LifeCycle {
+
     /**
-     * init
+     * Deprecated, use startup instead.
      */
+    @Deprecated
     void init();
 
     /**
@@ -97,7 +99,9 @@ public interface ConnectionManager extends Scannable {
 
     /**
      * Remove and close all connections from all {@link ConnectionPool}.
+     * Deprecated, use shutdown instead.
      */
+    @Deprecated
     void removeAll();
 
     /**

--- a/src/main/java/com/alipay/remoting/DefaultClientConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultClientConnectionManager.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.remoting;
+
+import com.alipay.remoting.config.switches.GlobalSwitch;
+import com.alipay.remoting.connection.ConnectionFactory;
+
+/**
+ * Do some preparatory work in order to refactor the ConnectionManager in the next version.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2019-03-07 14:27
+ */
+public class DefaultClientConnectionManager extends DefaultConnectionManager implements
+                                                                            ClientConnectionManager {
+
+    public DefaultClientConnectionManager(ConnectionSelectStrategy connectionSelectStrategy,
+                                          ConnectionFactory connectionFactory,
+                                          ConnectionEventHandler connectionEventHandler,
+                                          ConnectionEventListener connectionEventListener) {
+        super(connectionSelectStrategy, connectionFactory, connectionEventHandler,
+            connectionEventListener);
+    }
+
+    public DefaultClientConnectionManager(ConnectionSelectStrategy connectionSelectStrategy,
+                                          ConnectionFactory connectionFactory,
+                                          ConnectionEventHandler connectionEventHandler,
+                                          ConnectionEventListener connectionEventListener,
+                                          GlobalSwitch globalSwitch) {
+        super(connectionSelectStrategy, connectionFactory, connectionEventHandler,
+            connectionEventListener, globalSwitch);
+    }
+
+    @Override
+    public void startup() throws LifeCycleException {
+        super.startup();
+
+        this.connectionEventHandler.setConnectionManager(this);
+        this.connectionEventHandler.setConnectionEventListener(connectionEventListener);
+        this.connectionFactory.init(connectionEventHandler);
+    }
+
+}

--- a/src/main/java/com/alipay/remoting/DefaultServerConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/DefaultServerConnectionManager.java
@@ -17,16 +17,15 @@
 package com.alipay.remoting;
 
 /**
- * Async context for biz.
- * 
- * @author xiaomin.cxm
- * @version $Id: AsyncContext.java, v 0.1 May 19, 2016 2:19:05 PM xiaomin.cxm Exp $
+ * Do some preparatory work in order to refactor the ConnectionManager in the next version.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2019-03-07 14:40
  */
-public interface AsyncContext {
-    /**
-     * send response back
-     * 
-     * @param responseObject response object
-     */
-    void sendResponse(Object responseObject);
+public class DefaultServerConnectionManager extends DefaultConnectionManager implements
+                                                                            ServerConnectionManager {
+
+    public DefaultServerConnectionManager(ConnectionSelectStrategy connectionSelectStrategy) {
+        super(connectionSelectStrategy);
+    }
+
 }

--- a/src/main/java/com/alipay/remoting/ServerConnectionManager.java
+++ b/src/main/java/com/alipay/remoting/ServerConnectionManager.java
@@ -17,16 +17,10 @@
 package com.alipay.remoting;
 
 /**
- * Async context for biz.
- * 
- * @author xiaomin.cxm
- * @version $Id: AsyncContext.java, v 0.1 May 19, 2016 2:19:05 PM xiaomin.cxm Exp $
+ * Connection manager in server side.
+ *
+ * @author chengyi (mark.lx@antfin.com) 2019-03-07 12:13
  */
-public interface AsyncContext {
-    /**
-     * send response back
-     * 
-     * @param responseObject response object
-     */
-    void sendResponse(Object responseObject);
+public interface ServerConnectionManager extends ConnectionManager, LifeCycle {
+
 }

--- a/src/main/java/com/alipay/remoting/rpc/RpcServer.java
+++ b/src/main/java/com/alipay/remoting/rpc/RpcServer.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.alipay.remoting.DefaultServerConnectionManager;
 import org.slf4j.Logger;
 
 import com.alipay.remoting.AbstractRemotingServer;
@@ -123,7 +124,7 @@ public class RpcServer extends AbstractRemotingServer {
     private RemotingAddressParser                       addressParser;
 
     /** connection manager */
-    private DefaultConnectionManager                    connectionManager;
+    private DefaultServerConnectionManager              connectionManager;
 
     /** rpc remoting */
     protected RpcRemoting                               rpcRemoting;
@@ -227,8 +228,10 @@ public class RpcServer extends AbstractRemotingServer {
             this.addressParser = new RpcAddressParser();
         }
         if (this.switches().isOn(GlobalSwitch.SERVER_MANAGE_CONNECTION_SWITCH)) {
+            this.connectionManager = new DefaultServerConnectionManager(new RandomSelectStrategy());
+            this.connectionManager.startup();
+
             this.connectionEventHandler = new RpcConnectionEventHandler(switches());
-            this.connectionManager = new DefaultConnectionManager(new RandomSelectStrategy());
             this.connectionEventHandler.setConnectionManager(this.connectionManager);
             this.connectionEventHandler.setConnectionEventListener(this.connectionEventListener);
         } else {
@@ -322,7 +325,7 @@ public class RpcServer extends AbstractRemotingServer {
         }
         if (this.switches().isOn(GlobalSwitch.SERVER_MANAGE_CONNECTION_SWITCH)
             && null != this.connectionManager) {
-            this.connectionManager.removeAll();
+            this.connectionManager.shutdown();
             logger.warn("Close all connections from server side!");
         }
         logger.warn("Rpc Server stopped!");

--- a/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/ConcurrentCreateConnectionTest.java
@@ -18,6 +18,7 @@ package com.alipay.remoting.inner.connection;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.alipay.remoting.DefaultClientConnectionManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,7 +31,6 @@ import com.alipay.remoting.ConnectionEventHandler;
 import com.alipay.remoting.ConnectionEventListener;
 import com.alipay.remoting.ConnectionEventType;
 import com.alipay.remoting.ConnectionSelectStrategy;
-import com.alipay.remoting.DefaultConnectionManager;
 import com.alipay.remoting.RandomSelectStrategy;
 import com.alipay.remoting.RemotingAddressParser;
 import com.alipay.remoting.Url;
@@ -56,7 +56,7 @@ public class ConcurrentCreateConnectionTest {
                                                                                      .getLogger(RpcConnectionManagerTest.class);
     private ConcurrentHashMap<String, UserProcessor<?>> userProcessors           = new ConcurrentHashMap<String, UserProcessor<?>>();
 
-    private DefaultConnectionManager                    cm;
+    private DefaultClientConnectionManager              cm;
     private ConnectionSelectStrategy                    connectionSelectStrategy = new RandomSelectStrategy();
     private RemotingAddressParser                       addressParser            = new RpcAddressParser();
     private ConnectionFactory                           connectionFactory        = new RpcConnectionFactory(
@@ -74,10 +74,10 @@ public class ConcurrentCreateConnectionTest {
 
     @Before
     public void init() {
-        cm = new DefaultConnectionManager(connectionSelectStrategy, connectionFactory,
+        cm = new DefaultClientConnectionManager(connectionSelectStrategy, connectionFactory,
             connectionEventHandler, connectionEventListener);
         cm.setAddressParser(addressParser);
-        cm.init();
+        cm.startup();
         server = new BoltServer(port);
         server.start();
         server.addConnectionEventProcessor(ConnectionEventType.CONNECT, serverConnectProcessor);

--- a/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
+++ b/src/test/java/com/alipay/remoting/inner/connection/RpcConnectionManagerTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.alipay.remoting.DefaultClientConnectionManager;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,7 +59,7 @@ public class RpcConnectionManagerTest {
 
     private ConcurrentHashMap<String, UserProcessor<?>> userProcessors           = new ConcurrentHashMap<String, UserProcessor<?>>();
 
-    private DefaultConnectionManager                    cm;
+    private DefaultClientConnectionManager              cm;
     private ConnectionSelectStrategy                    connectionSelectStrategy = new RandomSelectStrategy();
     private RemotingAddressParser                       addressParser            = new RpcAddressParser();
     private ConnectionFactory                           connectionFactory        = new RpcConnectionFactory(
@@ -79,10 +80,10 @@ public class RpcConnectionManagerTest {
 
     @Before
     public void init() {
-        cm = new DefaultConnectionManager(connectionSelectStrategy, connectionFactory,
+        cm = new DefaultClientConnectionManager(connectionSelectStrategy, connectionFactory,
             connectionEventHandler, connectionEventListener);
         cm.setAddressParser(addressParser);
-        cm.init();
+        cm.startup();
         server = new BoltServer(port);
         server.start();
         server.addConnectionEventProcessor(ConnectionEventType.CONNECT, serverConnectProcessor);


### PR DESCRIPTION
核心变更：

* 拆分ConnectionManager为ClientConnectionManager和ServerConnectionManager，因为客户端和服务端对Connection的管理职责是不一样的，先拆开，为了后续重构做准备
* ConnectionManager增加统一的startup/shutdown接口，解决RpcClient/RpcServer stop时只是removeAll connection并没有关闭内部线程池的问题

其他变更：

* 补充一些代码注释